### PR TITLE
🐛 Spigotの並列ビルドに対応

### DIFF
--- a/src-electron/core/const.ts
+++ b/src-electron/core/const.ts
@@ -33,9 +33,6 @@ export const DATAPACK_CACHE_PATH = ADDITIONALS_CACHE_PATH.child('datapacks');
 export const PLUGIN_CACHE_PATH = ADDITIONALS_CACHE_PATH.child('plugins');
 export const MOD_CACHE_PATH = ADDITIONALS_CACHE_PATH.child('mods');
 
-/** spigotをビルドするためのキャッシュパス */
-export const spigotBuildPath = cachePath.child('spigotBuild');
-
 /** zipファイルを展開するための一時パス */
 export const unzipPath = tempPath.child('zip');
 


### PR DESCRIPTION
Spigotのビルドを一時的に確保したフォルダ内で行うことでバージョンにかかわらず並列ビルドを行うことができるように修正