### PR TITLE
✨ サーバー実行時にポート番号が利用可能かをチェックする

### DIFF
--- a/src-electron/core/world/handler.ts
+++ b/src-electron/core/world/handler.ts
@@ -33,9 +33,9 @@ import { asyncMap } from 'app/src-electron/util/objmap';
 import { getBackUpPath, parseBackUpPath } from './backup';
 import { Path } from 'app/src-electron/util/path';
 import { createTar, decompressTar } from 'app/src-electron/util/tar';
-import { BACKUP_EXT } from '../const';
 import { BackupData } from 'app/src-electron/schema/filedata';
 import { allocateTempDir } from '../misc/tempPath';
+import { portInUse } from 'app/src-electron/util/port';
 
 /** 複数の処理を並列で受け取って直列で処理 */
 class PromiseSpooler {
@@ -121,6 +121,8 @@ export class WorldHandler {
   container: WorldContainer;
   id: WorldID;
   runner: RunRebootableServer | undefined;
+  /** サーバーが実行中の場合のみポート番号が入る */
+  port: number | undefined;
 
   private constructor(id: WorldID, name: WorldName, container: WorldContainer) {
     this.promiseSpooler = new PromiseSpooler();
@@ -748,6 +750,33 @@ export class WorldHandler {
     const settings = constructWorldSettings(beforeWorld);
     const savePath = this.getSavePath();
 
+    // ポート番号を取得
+    let port = 25565;
+    if (isValid(beforeWorld.properties)) {
+      const serverPort = beforeWorld.properties['server-port'];
+      if (typeof serverPort === 'number') port = serverPort;
+    }
+
+    // ポートが使用中か確認
+    let portIsUsed = await portInUse(port);
+
+    // サーバーランナーの中で同じポートをしようとしているものがないか確認
+    portIsUsed ||= Object.values(WorldHandler.worldHandlerMap).some(
+      (x) => x.port === port
+    );
+
+    if (portIsUsed) {
+      return withError(
+        errorMessage.core.world.serverPortIsUsed({
+          port,
+        }),
+        errors
+      );
+    }
+
+    // ポートを登録
+    this.port = port;
+
     // 使用中フラグを立てて保存
     // 使用中フラグを折って保存を試みる (無理なら諦める)
     settings.using = true;
@@ -783,6 +812,9 @@ export class WorldHandler {
 
     // サーバーの終了を待機
     const serverResult = await runPromise;
+
+    // ポートを削除
+    this.port = undefined;
 
     this.runner = undefined;
 

--- a/src-electron/util/error/schema/core.ts
+++ b/src-electron/util/error/schema/core.ts
@@ -11,6 +11,11 @@ export type CoreErrors = {
       name?: string;
     }>;
 
+    // ポート番号が既に使用中
+    serverPortIsUsed: ErrorMessageContent<{
+      port: number;
+    }>;
+
     // 実行中のワールド名/ワールドフォルダは変更できない
     cannotChangeRunningWorldName: ErrorMessageContent<{
       name: string;

--- a/src-electron/util/port.ts
+++ b/src-electron/util/port.ts
@@ -1,0 +1,23 @@
+import * as net from 'net';
+
+/** ポートが使用中か確認する */
+export async function portInUse(port: number): Promise<boolean> {
+  const p = new Promise<boolean>((resolve) => {
+    const server = net.createServer((socket) => {
+      socket.write('Echo server\r\n');
+      socket.pipe(socket);
+    });
+
+    server.on('error', () => {
+      resolve(true);
+    });
+
+    server.on('listening', () => {
+      server.close();
+      resolve(false);
+    });
+
+    server.listen(port, '127.0.0.1');
+  });
+  return await p;
+}


### PR DESCRIPTION
サーバー実行時にポート番号が利用可能かをチェックする

エラー翻訳キー`core.world.serverPortIsUsed`を追加