### PR TITLE
pull request発行時にassigneeを自動割り当てするactionを追加

### DIFF
--- a/.github/wokflows/auto_assign.yml
+++ b/.github/wokflows/auto_assign.yml
@@ -1,0 +1,19 @@
+name: AutoPullRequestAssign
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  auto-assign:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - run: 'echo i_am_${{github.event.pull_request.user.login}}'
+      - name: 'Auto-assign PR'
+        uses: pozil/auto-assign-issue@v1
+        with:
+          repo-token: ${{ secrets.ACTION_ACCESS_TOKEN }}
+          assignees: ${{github.event.pull_request.user.login}}
+          numOfAssignee: 1

--- a/.github/wokflows/auto_assign.yml
+++ b/.github/wokflows/auto_assign.yml
@@ -10,7 +10,6 @@ jobs:
     permissions:
       issues: write
     steps:
-      - run: 'echo i_am_${{github.event.pull_request.user.login}}'
       - name: 'Auto-assign PR'
         uses: pozil/auto-assign-issue@v1
         with:


### PR DESCRIPTION
<!-- このPRはブランチを切った後，直ちに作成し，ブランチ内で変更する箇所を次章に列挙する -->

<!-- PRの作成時にはLabelsとAssignees（担当者）を割り当て，責任の所在を明確にする -->
<!-- PRの内容をすべて実装した際にReviewersを指定して，変更管理の承認を受ける -->

# pull request発行時にassigneeを自動割り当てするactionを追加

<!-- Pull Requestの概要を２行程度で説明する -->
<!-- このPRはブランチを切った後，直ちに作成し，ブランチ内で変更する箇所を次章に列挙する -->


## 変更箇所
pullrequestの作成者をassigneeとして自動で割り当てる

使用する前にリポジトリのアクセス権限があるユーザーのPATを
リポジトリ設定 > Secrets and variables > actions > Repository secrets に "ACTION_ACCESS_TOKEN" というキーで登録する必要がある。

<!-- 変更内容を列挙し，小項目は必要に応じて利用する -->
<!-- Issuesから引用する際には「#00 を修正」のように記載し，Developmentに当該Issueを忘れずに登録する -->



<!--
## 承認者への申し送り事項

- 申し送り事項を記載しておく必要がある場合に追記する

-->
