### PR TITLE
デバッグモードで起動した際リリースのdraftを取得する

### DIFF
--- a/src-electron/electron-main.ts
+++ b/src-electron/electron-main.ts
@@ -31,8 +31,8 @@ async function createWindow() {
    * Initial window options
    */
 
-  // ビルド版 かつ 環境変数SERVERSTARTER_MODEがnoupdateでない 場合アップデートをチェック
-  if (!process.env.DEBUGGING && process.env.SERVERSTARTER_MODE !== "noupdate") {
+  // 環境変数SERVERSTARTER_MODEがnoupdateでない場合アップデートをチェック
+  if (process.env.SERVERSTARTER_MODE !== "noupdate") {
     await update();
   }
 

--- a/src-electron/updater/fetch.ts
+++ b/src-electron/updater/fetch.ts
@@ -20,8 +20,6 @@ export async function getLatestRelease(
     PAT
   );
 
-  console.log(json)
-
   if (isError(json)) return json;
 
   for (const i of json) {

--- a/src-electron/updater/fetch.ts
+++ b/src-electron/updater/fetch.ts
@@ -2,53 +2,59 @@ import { Failable } from '../schema/error';
 import { BytesData } from '../util/bytesData';
 import { errorMessage } from '../util/error/construct';
 import { isError } from '../util/error/error';
+import { listReleases } from '../util/github/schema/release';
 import { OsPlatform } from '../util/os';
 
 /** githubからリリース番号を取得 */
-export async function getLatestRelease(osPLatform: OsPlatform): Promise<Failable<GithubRelease>> {
+export async function getLatestRelease(
+  osPLatform: OsPlatform
+): Promise<Failable<GithubRelease>> {
+  // 環境変数SERVERSTARTER_MODEが"debug"だった場合は環境変数SERVERSTARTER_TOKENからgitのPATを取得
+  const PAT =
+    process.env.SERVERSTARTER_MODE === 'debug'
+      ? process.env.SERVERSTARTER_TOKEN
+      : undefined;
 
-  // 環境変数SERVERSTARTER_MODEが"debug"だった場合はリリースの取得元を変更
-  const isDebug = process.env.SERVERSTARTER_MODE === "debug"
+  const json = await listReleases(
+    'Server-Starter-for-Minecraft',
+    'ServerStarter2',
+    PAT
+  );
 
-  const SERVERSTARTER_REPOSITORY_URL = isDebug ?
-    'https://api.github.com/repos/CivilTT/ServerStarter2-ReleaseTest/releases' :
-    'https://api.github.com/repos/CivilTT/ServerStarter2/releases';
-
-  const fetch = await BytesData.fromURL(SERVERSTARTER_REPOSITORY_URL);
-
-  if (isError(fetch)) return fetch;
-  const json = await fetch.json<GithubReleaseResponce[]>();
   if (isError(json)) return json;
-
-
 
   for (const i of json) {
     const url = parseAssets(i.assets, osPLatform);
-    if (url) return {
-      platform: osPLatform,
-      version: i.tag_name,
-      url
-    }
+    if (url)
+      return {
+        platform: osPLatform,
+        version: i.tag_name,
+        url,
+      };
   }
 
   return errorMessage.system.assertion({ message: '' });
 }
 
-function parseAssets(assets: GithubReleaseAssetResponce[], osPLatform: OsPlatform) {
+function parseAssets(
+  assets: GithubReleaseAssetResponce[],
+  osPLatform: OsPlatform
+) {
   const suffix = {
-    'linux': '.AppImage',
-    'mac-os': ".pkg",
-    'mac-os-arm64': ".pkg",
-    'windows-x64': ".msi",
-  }[osPLatform]
+    linux: '.AppImage',
+    'mac-os': '.pkg',
+    'mac-os-arm64': '.pkg',
+    'windows-x64': '.msi',
+  }[osPLatform];
 
-  return assets.find(({ browser_download_url: url }) => url.endsWith(suffix))?.browser_download_url;
+  return assets.find(({ browser_download_url: url }) => url.endsWith(suffix))
+    ?.browser_download_url;
 }
 
 export type GithubRelease = {
-  platform: OsPlatform
+  platform: OsPlatform;
   version: string;
-  url: string
+  url: string;
 };
 
 type GithubReleaseResponce = {

--- a/src-electron/updater/fetch.ts
+++ b/src-electron/updater/fetch.ts
@@ -1,8 +1,7 @@
 import { Failable } from '../schema/error';
-import { BytesData } from '../util/bytesData';
 import { errorMessage } from '../util/error/construct';
 import { isError } from '../util/error/error';
-import { listReleases } from '../util/github/schema/release';
+import { ReleaseAsset, listReleases } from '../util/github/schema/release';
 import { OsPlatform } from '../util/os';
 
 /** githubからリリース番号を取得 */
@@ -37,7 +36,7 @@ export async function getLatestRelease(
 }
 
 function parseAssets(
-  assets: GithubReleaseAssetResponce[],
+  assets: ReleaseAsset[],
   osPLatform: OsPlatform
 ) {
   const suffix = {
@@ -55,17 +54,4 @@ export type GithubRelease = {
   platform: OsPlatform;
   version: string;
   url: string;
-};
-
-type GithubReleaseResponce = {
-  tag_name: string;
-  name: string;
-  draft: boolean;
-  prerelease: boolean;
-  published_at: string;
-  assets: GithubReleaseAssetResponce[];
-};
-
-type GithubReleaseAssetResponce = {
-  browser_download_url: string;
 };

--- a/src-electron/updater/fetch.ts
+++ b/src-electron/updater/fetch.ts
@@ -20,6 +20,8 @@ export async function getLatestRelease(
     PAT
   );
 
+  console.log(json)
+
   if (isError(json)) return json;
 
   for (const i of json) {

--- a/src-electron/updater/updater.ts
+++ b/src-electron/updater/updater.ts
@@ -33,14 +33,12 @@ export async function update() {
   const update = await checkUpdate();
   logger.info(update);
 
+  if (update === false) return;
 
-  if (update === false) {
-    return;
-  }
+  if (isError(update)) return;
 
-  if (isError(update)) {
-    return;
-  }
+  // 環境変数DEBUGGING==true(yarn devで起動した場合)実際のアップデート処理は行わない
+  if (process.env.DEBUGGING) return;
 
   // lastUpdatedTimeをundefinedに
   const sys = await getSystemSettings();

--- a/src-electron/util/github/rest.ts
+++ b/src-electron/util/github/rest.ts
@@ -1,0 +1,27 @@
+import { BytesData } from '../bytesData';
+import { isError } from '../error/error';
+import { Failable } from '../error/failable';
+
+type RequestHeader = {
+  Accept: string;
+  Authorization?: string;
+};
+
+export async function getJsonResponse<T>(
+  url: string,
+  pat?: string,
+  accept = 'application/vnd.github+json'
+): Promise<Failable<T>> {
+  // PATの認証情報をヘッダーに付与してfetch
+  const requestHeader: RequestHeader = { Accept: accept };
+
+  if (pat !== undefined) requestHeader.Authorization = `Bearer ${pat}`;
+
+  const responce = await BytesData.fromURL(url, undefined, requestHeader);
+
+  if (isError(responce)) return responce;
+
+  // jsonを取得
+  const json = await responce.json<T>();
+  return json;
+}

--- a/src-electron/util/github/schema/release.ts
+++ b/src-electron/util/github/schema/release.ts
@@ -13,7 +13,7 @@ export type ReleaseAsset = {
   download_count: number;
   created_at: string;
   updated_at: string;
-  uploader: {};
+  uploader: any;
 };
 
 export type Release = {
@@ -33,7 +33,7 @@ export type Release = {
   prerelease: boolean;
   created_at: string;
   published_at: string;
-  author: {};
+  author: any;
   assets: ReleaseAsset[];
 };
 

--- a/src-electron/util/github/schema/release.ts
+++ b/src-electron/util/github/schema/release.ts
@@ -1,0 +1,51 @@
+import { getJsonResponse } from '../rest';
+
+export type ReleaseAsset = {
+  url: string;
+  browser_download_url: string;
+  id: 1;
+  node_id: string;
+  name: string;
+  label: string;
+  state: 'uploaded' | 'open';
+  content_type: string;
+  size: number;
+  download_count: number;
+  created_at: string;
+  updated_at: string;
+  uploader: {};
+};
+
+export type Release = {
+  url: string;
+  html_url: string;
+  assets_url: string;
+  upload_url: string;
+  tarball_url: string;
+  zipball_url: string;
+  id: 1;
+  node_id: string;
+  tag_name: string;
+  target_commitish: string;
+  name: string;
+  body: string;
+  draft: boolean;
+  prerelease: boolean;
+  created_at: string;
+  published_at: string;
+  author: {};
+  assets: ReleaseAsset[];
+};
+
+export async function listReleases(
+  owner: string,
+  repo: string,
+  pat?: string,
+  accept = 'application/vnd.github+json'
+) {
+  return getJsonResponse<Release[]>(
+    `https://api.github.com/repos/${owner}/${repo}/releases`,
+    pat,
+    accept
+  );
+}


### PR DESCRIPTION
# デバッグモードで起動した際リリースのdraftを取得する

環境変数を以下のように指定してビルド版を起動したとき、autoUpdaterがdraft状態のリリースも取得するように変更
```
SERVERSTARTER_MODE = debug
SERVERSTARTER_TOKEN = {GitHub personal access token}
```

この変更により、開発者が本リリース前にリリースが正常かを確認できる。