### PR TITLE
Orginizationのメンバー以外の人がPRを出した場合AutoAssignしない

### DIFF
--- a/.github/workflows/auto_assign.yml
+++ b/.github/workflows/auto_assign.yml
@@ -1,5 +1,9 @@
 name: AutoPullRequestAssign
 
+permissions:
+  issues: write
+  pull-requests: write
+
 on:
   pull_request:
     types: [opened]
@@ -7,12 +11,19 @@ on:
 jobs:
   auto-assign:
     runs-on: ubuntu-latest
-    permissions:
-      issues: write
     steps:
-      - name: 'Auto-assign PR'
+      - name: Check if organization member
+        id: is_organization_member
+        uses: JamesSingleton/is-organization-member@1.0.0
+        with:
+          organization: Server-Starter-for-Minecraft
+          username: ${{ github.event.pull_request.user.login }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Auto Assign Pull Request
+        if: ${{ steps.is_organization_member.outputs.result == 'true' }}
         uses: pozil/auto-assign-issue@v1
         with:
-          repo-token: ${{ secrets.ACTION_ACCESS_TOKEN }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
           assignees: ${{github.event.pull_request.user.login}}
           numOfAssignee: 1


### PR DESCRIPTION
<!-- このPRはブランチを切った後，直ちに作成し，ブランチ内で変更する箇所を次章に列挙する -->

<!-- PRの作成時にはLabelsとAssignees（担当者）を割り当て，責任の所在を明確にする -->
<!-- PRの内容をすべて実装した際にReviewersを指定して，変更管理の承認を受ける -->

# タイトル
Orginizationのメンバー以外の人がPRを出した場合AutoAssignしない

<!-- Pull Requestの概要を２行程度で説明する -->
<!-- このPRはブランチを切った後，直ちに作成し，ブランチ内で変更する箇所を次章に列挙する -->

## 変更箇所

<!-- 変更内容を列挙し，小項目は必要に応じて利用する -->
<!-- Issuesから引用する際には「#00 を修正」のように記載し，Developmentに当該Issueを忘れずに登録する -->

`JamesSingleton/is-organization-member@1.0.0`を使用してPRの作成者がOrginizationのメンバーかどうかをチェック
Orginizationのメンバーだった場合のみAssignerをPR作成者に割り当てる

<!--
## 承認者への申し送り事項

- 申し送り事項を記載しておく必要がある場合に追記する

-->

## 留意事項
`JamesSingleton/is-organization-member@1.0.0`かなりレガシーな機能(SetOutput)を使用しており利用できなくなる可能性があるので、別のアクションを探すか自作するほうが良い