### PR TITLE
SetWorldにおいてCustomMapを導入する処理場合に限りAdditional設定を反映しない

### DIFF
--- a/src-electron/core/world/local.ts
+++ b/src-electron/core/world/local.ts
@@ -222,10 +222,16 @@ export async function saveLocalFiles(
   const promisses: Promise<any>[] = [
     serverJsonFile.save(savePath, worldSettings),
     serverIconFile.save(savePath, world.avater_path),
-    serverAllAdditionalFiles
-      .save(savePath, world.additional)
-      .then((v) => errors.push(...v.errors)),
   ];
+
+  // custom_mapがある場合はAdditionalを保存しない
+  if (!world.custom_map) {
+    promisses.push(
+      serverAllAdditionalFiles
+        .save(savePath, world.additional)
+        .then((v) => errors.push(...v.errors))
+    );
+  }
 
   // world.playersが正常値の場合ファイル(ops.json,whitelist.json)に保存
   if (isValid(world.players)) {


### PR DESCRIPTION
# SetWorldにおいてCustomMapを導入する処理場合に限りAdditional設定を反映しない
CustomMapを導入する際にCustomMapに組み込まれたデータパックが消滅する問題がおこるため、その場合にかぎりワールドのAdditionalの設定を反映せず、CustomMapに組み込まれたデータパックのみを反映させる実装へと変更した。

この変更は将来的に修正されるべきであり、望ましい挙動は元のワールドのAdditionalとCustomMapのAdditionalが適切にマージされるといったものであろう。
現状のUIではCustomMapの導入は初回時にのみ行われるため、この問題がユーザーに与える影響はない。