### PR TITLE
ワールドの複製後にダイアログが消えるように修正

### DIFF
--- a/src/components/MainLayout/CustomMapImporter/checkDialog.vue
+++ b/src/components/MainLayout/CustomMapImporter/checkDialog.vue
@@ -23,7 +23,6 @@ async function importProcess() {
   <q-dialog ref="dialogRef" @hide="onDialogHide" persistent>
     <BaseDialogCard
       :title="$t('mainLayout.customMapImporter.checkDialog.title')"
-      @close="onDialogCancel"
       style="max-width: 100%"
     >
       <q-item dense class="q-pl-none">

--- a/src/components/MainLayout/RecoverDialog/RecoverDialog.vue
+++ b/src/components/MainLayout/RecoverDialog/RecoverDialog.vue
@@ -48,8 +48,8 @@ async function recoverWorld() {
       :title="$T('mainLayout.backupDialog.title')"
       :loading="loading"
       :ok-btn-txt="$T('mainLayout.backupDialog.startRecover')"
+      :onClose="loading ? undefined : onDialogCancel"
       @ok-click="recoverWorld"
-      @close="onDialogCancel"
     >
       <p>{{ $t('mainLayout.backupDialog.desc') }}</p>
       <ul>

--- a/src/components/SystemSettings/General/OwnerSetter/OwnerDialog.vue
+++ b/src/components/SystemSettings/General/OwnerSetter/OwnerDialog.vue
@@ -33,8 +33,8 @@ function registOwner() {
       :title="$t('owner.set')"
       :okBtnTxt="$t('owner.registBtn')"
       :disable="ownerCandidate === void 0"
+      :onClose="persistent ? undefined : onDialogOK"
       @okClick="registOwner"
-      @close="onDialogOK"
     >
       <template #default>
         <p

--- a/src/components/SystemSettings/Remote/NewRemoteDialog.vue
+++ b/src/components/SystemSettings/Remote/NewRemoteDialog.vue
@@ -61,8 +61,8 @@ async function okClick() {
       :title="$t('shareWorld.registerNewRemote')"
       :loading="loading"
       :ok-btn-txt="$t('shareWorld.register')"
+      :onClose="loading ? undefined : onDialogCancel"
       @ok-click="okClick"
-      @close="onDialogCancel"
     >
       <div class="q-pb-sm">
         <div class="caption" style="opacity: 0.6">

--- a/src/components/World/ShareWorld/selecters/github/ExistedGitHubDialog.vue
+++ b/src/components/World/ShareWorld/selecters/github/ExistedGitHubDialog.vue
@@ -47,8 +47,8 @@ async function setRemote() {
       "
       :ok-btn-txt="$t('shareWorld.sync', { path: `${rWorldName}` })"
       :loading="loading"
+      :onClose="loading ? undefined : onDialogCancel"
       @ok-click="setRemote"
-      @close="onDialogCancel"
     >
       <p
         style="font-size: 0.8rem; opacity: 0.8"

--- a/src/components/World/ShareWorld/selecters/github/NewGitHubDialog.vue
+++ b/src/components/World/ShareWorld/selecters/github/NewGitHubDialog.vue
@@ -65,8 +65,8 @@ async function setRemote() {
       :ok-btn-txt="$t('shareWorld.newRemote.btn')"
       :loading="loading"
       :disable="!isValidName"
+      :onClose="loading ? undefined : onDialogCancel"
       @ok-click="setRemote"
-      @close="onDialogCancel"
     >
       <p style="font-size: 0.8rem; opacity: 0.8">
         <i18n-t keypath="shareWorld.newRemote.desc" tag="false">

--- a/src/pages/WorldTabs/HomePage.vue
+++ b/src/pages/WorldTabs/HomePage.vue
@@ -16,7 +16,7 @@ const scrollAreaRef = ref();
  * 画面を一番上に遷移
  */
 function scrollTop() {
-  scrollAreaRef.value.scrollTop = 0
+  scrollAreaRef.value.scrollTop = 0;
 }
 setScrollTop(scrollTop);
 </script>

--- a/src/pages/WorldTabs/HomePage.vue
+++ b/src/pages/WorldTabs/HomePage.vue
@@ -16,13 +16,13 @@ const scrollAreaRef = ref();
  * 画面を一番上に遷移
  */
 function scrollTop() {
-  scrollAreaRef.value.setScrollPosition('vertical', 0);
+  scrollAreaRef.value.scrollTop = 0
 }
 setScrollTop(scrollTop);
 </script>
 
 <template>
-  <div class="vertical-scroll">
+  <div ref="scrollAreaRef" class="vertical-scroll">
     <div class="mainField">
       <RunningBtn
         to="/console"
@@ -56,6 +56,4 @@ setScrollTop(scrollTop);
       <WorldDeleteView />
     </div>
   </div>
-  <!-- <q-scroll-area ref="scrollAreaRef" class="full-height" style="flex: 1 1 0;">
-  </q-scroll-area> -->
 </template>


### PR DESCRIPTION
<!-- このPRはブランチを切った後，直ちに作成し，ブランチ内で変更する箇所を次章に列挙する -->

<!-- PRの作成時にはLabelsとAssignees（担当者）を割り当て，責任の所在を明確にする -->
<!-- PRの内容をすべて実装した際にReviewersを指定して，変更管理の承認を受ける -->

# ワールド複製後のダイアログ修正
#137 の修正
HOME画面修正時に定義が消し飛んだ変数を復旧

<!-- Pull Requestの概要を２行程度で説明する -->
<!-- このPRはブランチを切った後，直ちに作成し，ブランチ内で変更する箇所を次章に列挙する -->


## 変更箇所
<!-- 変更内容を列挙し，小項目は必要に応じて利用する -->
<!-- Issuesから引用する際には「#00 を修正」のように記載し，Developmentに当該Issueを忘れずに登録する -->
- [x] `HomePage.vue`の`scrollAreaRef`を再定義
- [x] 各ダイアログにおいて`persistent`がかかっているときに右上の閉じるボタンからダイアログを閉じることができてしまう問題の修正


<!--
## 承認者への申し送り事項

- 申し送り事項を記載しておく必要がある場合に追記する

-->