### PR TITLE
🚑 システムが最新かどうかを比較するバージョン文字列に接頭辞"v"をつける

### DIFF
--- a/src-electron/updater/fetch.ts
+++ b/src-electron/updater/fetch.ts
@@ -44,6 +44,7 @@ function parseAssets(assets: ReleaseAsset[], osPLatform: OsPlatform) {
 
 export type GithubRelease = {
   platform: OsPlatform;
+  /** 接頭辞vのついたSemVar e.g. "v1.2.3" */
   version: string;
   url: string;
 };

--- a/src-electron/updater/updater.ts
+++ b/src-electron/updater/updater.ts
@@ -14,12 +14,13 @@ import { getSystemVersion } from './version';
  * リモートのバージョンはgithubのリリース情報のtag_nameを参照
  */
 async function checkUpdate(pat: string | undefined) {
+  /** 接頭辞vのついていないSemVar e.g. "1.2.3" */
   const currentVersion = await getSystemVersion();
   const latestRelease = await getLatestRelease(osPlatform, pat);
   // アップデートの取得に失敗
   if (isError(latestRelease)) return latestRelease;
   // アップデートなし
-  if (currentVersion === latestRelease.version) return false;
+  if ('v' + currentVersion === latestRelease.version) return false;
   return latestRelease;
 }
 


### PR DESCRIPTION
# システムが最新かどうかを比較するバージョン文字列に接頭辞"v"をつける

システムがアップデートを行う際に
github上でのバージョン名: 'v2.1.3' と electron上でのバージョン名: '2.1.3' が異なる文字列であるために最新版にもかかわらずアップデータが実行され無限ループする現象を修正しました。