### PR TITLE
NgrokのbinPath引数を削除

### DIFF
--- a/src-electron/core/server/setup/ngrok.ts
+++ b/src-electron/core/server/setup/ngrok.ts
@@ -18,7 +18,7 @@ export async function runNgrok(
       addr: port,
       authtoken: token,
       remote_addr,
-      binPath: (path) => path.replace('app.asar', 'app.asar.unpacked'),
+      // binPath: (path) => path.replace('app.asar', 'app.asar.unpacked'),
     });
 
     return listener;


### PR DESCRIPTION
### 概要
Ngrokの設定でbinPathに関数を指定していたが、関数指定のオプションが削除されたためbinPathを削除しました。

### テスト
以下の項目を開発版ではなくビルド版の仮想環境で検証してください
- ngrokを有効化したワールドが起動し、参加できることを各OSで確認