### PR TITLE
[SSF-47] eula.txtの生成を安全に行う

### DIFF
--- a/src-electron/core/server/setup/eula.ts
+++ b/src-electron/core/server/setup/eula.ts
@@ -137,10 +137,11 @@ async function generateEula(
     true
   );
 
-  // 60秒経っても終了していない場合はプロセスキル
+  // 60秒経っても終了していない場合はプロセスキルし、eula.txtをこちらで生成する
   (async () => {
     await sleep(60 * 1000);
     if (!process.finished()) process.kill();
+    await eulaPath.writeText('eula=false');
   })();
 
   const result = await process;

--- a/src-electron/util/dateFormatter.ts
+++ b/src-electron/util/dateFormatter.ts
@@ -2,6 +2,31 @@ function paddedNumber(n: number, digit: number) {
   return n.toString().padStart(digit, '0');
 }
 
+const monthNames = [
+  ['January', 'Jan'],
+  ['February', 'Feb'],
+  ['March', 'Mar'],
+  ['April', 'Apr'],
+  ['May', 'May'],
+  ['June', 'Jun'],
+  ['July', 'Jul'],
+  ['August', 'Aug'],
+  ['September', 'Sep'],
+  ['October', 'Oct'],
+  ['November', 'Nov'],
+  ['December', 'Dec'],
+];
+
+const dateNames = [
+  ['Sunday', 'Sun'],
+  ['Monday', 'Mon'],
+  ['Tuesday', 'Tues'],
+  ['Wednesday', 'Wed'],
+  ['Thursday', 'Thurs'],
+  ['Friday', 'Fri'],
+  ['Saturday', 'Sat'],
+];
+
 export class DateForFormatter {
   date: Date;
   constructor(date: Date) {
@@ -22,6 +47,34 @@ export class DateForFormatter {
 
   get HH() {
     return paddedNumber(this.date.getHours(), 2);
+  }
+
+  get mm() {
+    return paddedNumber(this.date.getMinutes(), 2);
+  }
+
+  get ss() {
+    return paddedNumber(this.date.getSeconds(), 2);
+  }
+
+  /** Sun-Sat */
+  get ddd() {
+    return dateNames[this.date.getDay()][1];
+  }
+
+  /** Sundat-Saturday */
+  get dddd() {
+    return dateNames[this.date.getDay()][0];
+  }
+
+  /** Jan / Feb / Mar / Apr / May / Jun / Jul / Aug / Sep / Oct / Nov / Dec */
+  get Mth() {
+    return monthNames[this.date.getMonth()][1];
+  }
+
+  /** January / February / March / April / May / June / July / August / September / October / November / December */
+  get Month() {
+    return monthNames[this.date.getMonth()][0];
   }
 }
 


### PR DESCRIPTION
eula.txtの生成がうまくいかないことがあるので、それらに対応したい。

現状サーバーを仮起動することでeula.txtを生成しているが、

- eula.txtが生成されるサーバーが終了する
- eula.txtが生成されずサーバーが終了する
- eula.txtが生成されずサーバーが続行する
- eula.txtが生成されずサーバーが応答しない

といった複数のパターンが確認されており個別での対処は困難であるため、仮起動せずにeula.txtを生成する方法も視野に入れる。