### PR TITLE
システム設定にスクロールバーを設定

### DIFF
--- a/src/css/app.scss
+++ b/src/css/app.scss
@@ -67,7 +67,7 @@ html {
   height: 100%;
   width: 80%;
   max-width: 1000px;
-  margin: 0 auto 32px auto;
+  margin: 0 auto;
 }
 
 // コンテンツを鉛直方向にのみスクロールさせるエリアを生成

--- a/src/pages/SystemSettings/GeneralPage.vue
+++ b/src/pages/SystemSettings/GeneralPage.vue
@@ -54,54 +54,56 @@ function showOwnerDialog() {
 </script>
 
 <template>
-  <div class="mainField">
-    <h1 class="q-mt-none">{{ $t('systemsetting.general.lang') }}</h1>
-    <SsSelect
-      dense
-      v-model="sysStore.systemSettings.user.language"
-      @update:model-value="(newVal) => changeLocale(newVal)"
-      :options="localeOptions"
-      option-label="label"
-      option-value="value"
-    />
-
-    <h1>{{ $t('systemsetting.general.colorMode') }}</h1>
-    <div class="row q-gutter-lg">
-      <template v-for="theme in colorThemes" :key="theme">
-        <ColorThemeBtn
-          :src="assets.svg[theme]()"
-          :active="sysStore.systemSettings.user.theme === theme"
-          :label="theme"
-          @click="() => changeTheme(theme)"
-        />
-      </template>
+  <div class="vertical-scroll">
+    <div class="mainField">
+      <h1 class="q-mt-none">{{ $t('systemsetting.general.lang') }}</h1>
+      <SsSelect
+        dense
+        v-model="sysStore.systemSettings.user.language"
+        @update:model-value="(newVal) => changeLocale(newVal)"
+        :options="localeOptions"
+        option-label="label"
+        option-value="value"
+      />
+  
+      <h1>{{ $t('systemsetting.general.colorMode') }}</h1>
+      <div class="row q-gutter-lg">
+        <template v-for="theme in colorThemes" :key="theme">
+          <ColorThemeBtn
+            :src="assets.svg[theme]()"
+            :active="sysStore.systemSettings.user.theme === theme"
+            :label="theme"
+            @click="() => changeTheme(theme)"
+          />
+        </template>
+      </div>
+      <q-toggle
+        v-model="sysStore.systemSettings.user.visionSupport"
+        @update:model-value="(val) => setColor($q.dark.isActive, val)"
+        :label="
+          sysStore.systemSettings.user.visionSupport
+            ? $t('systemsetting.general.useVisionSupport')
+            : $t('systemsetting.general.noVisionSupport')
+        "
+        class="q-pt-lg"
+        style="font-size: 1rem"
+      />
+  
+      <h1>{{ $t('owner.register') }}</h1>
+      <p class="q-my-sm text-body2" style="opacity: 0.5">
+        {{ $t('owner.generalDesc') }}
+      </p>
+      <PlayerCard v-model="sysStore.systemSettings.user.owner" />
+      <SsBtn
+        :label="`${
+          sysStore.systemSettings.user.owner
+            ? $t('owner.change')
+            : $t('owner.register')
+        }`"
+        :color="!sysStore.systemSettings.user.owner ? 'primary' : undefined"
+        @click="showOwnerDialog"
+        class="q-my-md"
+      />
     </div>
-    <q-toggle
-      v-model="sysStore.systemSettings.user.visionSupport"
-      @update:model-value="(val) => setColor($q.dark.isActive, val)"
-      :label="
-        sysStore.systemSettings.user.visionSupport
-          ? $t('systemsetting.general.useVisionSupport')
-          : $t('systemsetting.general.noVisionSupport')
-      "
-      class="q-pt-lg"
-      style="font-size: 1rem"
-    />
-
-    <h1>{{ $t('owner.register') }}</h1>
-    <p class="q-my-sm text-body2" style="opacity: 0.5">
-      {{ $t('owner.generalDesc') }}
-    </p>
-    <PlayerCard v-model="sysStore.systemSettings.user.owner" />
-    <SsBtn
-      :label="`${
-        sysStore.systemSettings.user.owner
-          ? $t('owner.change')
-          : $t('owner.register')
-      }`"
-      :color="!sysStore.systemSettings.user.owner ? 'primary' : undefined"
-      @click="showOwnerDialog"
-      class="q-my-md"
-    />
   </div>
 </template>

--- a/src/pages/SystemSettings/GeneralPage.vue
+++ b/src/pages/SystemSettings/GeneralPage.vue
@@ -65,7 +65,7 @@ function showOwnerDialog() {
         option-label="label"
         option-value="value"
       />
-  
+
       <h1>{{ $t('systemsetting.general.colorMode') }}</h1>
       <div class="row q-gutter-lg">
         <template v-for="theme in colorThemes" :key="theme">
@@ -88,7 +88,7 @@ function showOwnerDialog() {
         class="q-pt-lg"
         style="font-size: 1rem"
       />
-  
+
       <h1>{{ $t('owner.register') }}</h1>
       <p class="q-my-sm text-body2" style="opacity: 0.5">
         {{ $t('owner.generalDesc') }}

--- a/src/pages/SystemSettings/InfoPage.vue
+++ b/src/pages/SystemSettings/InfoPage.vue
@@ -34,7 +34,6 @@ function openMIT() {
 
 <template>
   <div class="vertical-scroll">
-
     <div class="q-px-md" style="margin: auto; width: fit-content">
       <h1 class="q-pt-md">{{ $t('systemsetting.info.systemVersion') }}</h1>
       <div class="q-pl-md">
@@ -54,7 +53,7 @@ function openMIT() {
             />
           </div>
         </div>
-  
+
         <!-- 最終更新日 -->
         <div
           v-if="lastUpdateDateTime"
@@ -68,7 +67,7 @@ function openMIT() {
           }}
         </div>
       </div>
-  
+
       <h1>{{ $t('systemsetting.info.systemLog') }}</h1>
       <div class="q-pl-md">
         <div class="text-caption" style="opacity: 0.6">
@@ -80,7 +79,7 @@ function openMIT() {
           class="q-mt-md"
         />
       </div>
-  
+
       <h1>{{ $t('systemsetting.info.externalLink') }}</h1>
       <div class="q-pl-md q-py-sm q-gutter-sm">
         <div class="row">
@@ -107,7 +106,7 @@ function openMIT() {
           </div>
         </div>
       </div>
-  
+
       <h1>{{ $t('systemsetting.info.license') }}</h1>
       <div class="q-pl-md">
         <div class="row items-start">
@@ -127,7 +126,7 @@ function openMIT() {
           v-html="$t('systemsetting.info.licenseDesc')"
         ></div>
       </div>
-  
+
       <h1>{{ $t('systemsetting.info.developer') }}</h1>
       <div class="q-pl-md">
         <CreaterItem
@@ -140,7 +139,10 @@ function openMIT() {
           :names="['txkodo']"
           url="https://twitter.com/txkodo"
         />
-        <CreaterItem :job="$t('systemsetting.info.support')" :names="['nozz']" />
+        <CreaterItem
+          :job="$t('systemsetting.info.support')"
+          :names="['nozz']"
+        />
       </div>
     </div>
   </div>

--- a/src/pages/SystemSettings/InfoPage.vue
+++ b/src/pages/SystemSettings/InfoPage.vue
@@ -33,112 +33,115 @@ function openMIT() {
 </script>
 
 <template>
-  <div class="q-px-md" style="margin: auto; width: fit-content">
-    <h1 class="q-pt-md">{{ $t('systemsetting.info.systemVersion') }}</h1>
-    <div class="q-pl-md">
-      <!-- バージョン名 -->
-      <div class="row items-center">
-        <p class="q-ma-none">{{ sysStore.systemVersion }}</p>
-        <div class="q-ml-md">
-          <p v-if="latest" class="q-ma-none">
-            {{ $t('systemsetting.info.latest') }}
-          </p>
-          <SsBtn
-            v-else
-            free-width
-            :label="$t('systemsetting.info.update')"
-            color="primary"
-            @click="systemUpdate"
-          />
+  <div class="vertical-scroll">
+
+    <div class="q-px-md" style="margin: auto; width: fit-content">
+      <h1 class="q-pt-md">{{ $t('systemsetting.info.systemVersion') }}</h1>
+      <div class="q-pl-md">
+        <!-- バージョン名 -->
+        <div class="row items-center">
+          <p class="q-ma-none">{{ sysStore.systemVersion }}</p>
+          <div class="q-ml-md">
+            <p v-if="latest" class="q-ma-none">
+              {{ $t('systemsetting.info.latest') }}
+            </p>
+            <SsBtn
+              v-else
+              free-width
+              :label="$t('systemsetting.info.update')"
+              color="primary"
+              @click="systemUpdate"
+            />
+          </div>
         </div>
-      </div>
-
-      <!-- 最終更新日 -->
-      <div
-        v-if="lastUpdateDateTime"
-        class="text-caption q-pt-sm"
-        style="opacity: 0.6"
-      >
-        {{
-          $t('systemsetting.info.finalUpdate', {
-            datetime: $d(lastUpdateDateTime, 'dateTime'),
-          })
-        }}
-      </div>
-    </div>
-
-    <h1>{{ $t('systemsetting.info.systemLog') }}</h1>
-    <div class="q-pl-md">
-      <div class="text-caption" style="opacity: 0.6">
-        {{ $t('systemsetting.info.systemLogDesc') }}
-      </div>
-      <SsBtn
-        :label="$t('systemsetting.info.openSystemLog')"
-        @click="openLog"
-        class="q-mt-md"
-      />
-    </div>
-
-    <h1>{{ $t('systemsetting.info.externalLink') }}</h1>
-    <div class="q-pl-md q-py-sm q-gutter-sm">
-      <div class="row">
-        <p class="q-ma-none" style="width: 12rem">
-          {{ $t('systemsetting.info.homepage') }}
-        </p>
-        <SsA
-          url="https://server-starter-for-minecraft.github.io"
-          class="text-body2"
-          style="width: 20rem"
+  
+        <!-- 最終更新日 -->
+        <div
+          v-if="lastUpdateDateTime"
+          class="text-caption q-pt-sm"
+          style="opacity: 0.6"
         >
-          https://server-starter-for-minecraft.github.io
-        </SsA>
-      </div>
-      <div class="row q-pt-sm">
-        <p class="q-ma-none" style="width: 12rem">
-          {{ $t('systemsetting.info.contact') }}
-        </p>
-        <div class="row" style="width: 20rem">
-          <SsA url="https://twitter.com/CivilT_T" class="text-body2">
-            https://twitter.com/CivilT_T
-          </SsA>
-          <span>{{ $t('systemsetting.info.dm') }}</span>
+          {{
+            $t('systemsetting.info.finalUpdate', {
+              datetime: $d(lastUpdateDateTime, 'dateTime'),
+            })
+          }}
         </div>
       </div>
-    </div>
-
-    <h1>{{ $t('systemsetting.info.license') }}</h1>
-    <div class="q-pl-md">
-      <div class="row items-start">
-        <p class="q-ma-none">{{ $t('systemsetting.info.MIT') }}</p>
-        <q-btn
-          flat
-          dense
-          icon="open_in_new"
-          color="grey"
-          size=".5rem"
-          @click="openMIT"
+  
+      <h1>{{ $t('systemsetting.info.systemLog') }}</h1>
+      <div class="q-pl-md">
+        <div class="text-caption" style="opacity: 0.6">
+          {{ $t('systemsetting.info.systemLogDesc') }}
+        </div>
+        <SsBtn
+          :label="$t('systemsetting.info.openSystemLog')"
+          @click="openLog"
+          class="q-mt-md"
         />
       </div>
-      <div
-        class="text-caption q-pt-sm"
-        style="opacity: 0.6"
-        v-html="$t('systemsetting.info.licenseDesc')"
-      ></div>
-    </div>
-
-    <h1>{{ $t('systemsetting.info.developer') }}</h1>
-    <div class="q-pl-md">
-      <CreaterItem
-        :job="$t('systemsetting.info.productionManager')"
-        :names="['CivilTT']"
-        url="https://twitter.com/CivilT_T"
-      />
-      <CreaterItem
-        :job="$t('systemsetting.info.technicalManager')"
-        :names="['txkodo']"
-        url="https://twitter.com/txkodo"
-      />
-      <CreaterItem :job="$t('systemsetting.info.support')" :names="['nozz']" />
+  
+      <h1>{{ $t('systemsetting.info.externalLink') }}</h1>
+      <div class="q-pl-md q-py-sm q-gutter-sm">
+        <div class="row">
+          <p class="q-ma-none" style="width: 12rem">
+            {{ $t('systemsetting.info.homepage') }}
+          </p>
+          <SsA
+            url="https://server-starter-for-minecraft.github.io"
+            class="text-body2"
+            style="width: 20rem"
+          >
+            https://server-starter-for-minecraft.github.io
+          </SsA>
+        </div>
+        <div class="row q-pt-sm">
+          <p class="q-ma-none" style="width: 12rem">
+            {{ $t('systemsetting.info.contact') }}
+          </p>
+          <div class="row" style="width: 20rem">
+            <SsA url="https://twitter.com/CivilT_T" class="text-body2">
+              https://twitter.com/CivilT_T
+            </SsA>
+            <span>{{ $t('systemsetting.info.dm') }}</span>
+          </div>
+        </div>
+      </div>
+  
+      <h1>{{ $t('systemsetting.info.license') }}</h1>
+      <div class="q-pl-md">
+        <div class="row items-start">
+          <p class="q-ma-none">{{ $t('systemsetting.info.MIT') }}</p>
+          <q-btn
+            flat
+            dense
+            icon="open_in_new"
+            color="grey"
+            size=".5rem"
+            @click="openMIT"
+          />
+        </div>
+        <div
+          class="text-caption q-pt-sm"
+          style="opacity: 0.6"
+          v-html="$t('systemsetting.info.licenseDesc')"
+        ></div>
+      </div>
+  
+      <h1>{{ $t('systemsetting.info.developer') }}</h1>
+      <div class="q-pl-md">
+        <CreaterItem
+          :job="$t('systemsetting.info.productionManager')"
+          :names="['CivilTT']"
+          url="https://twitter.com/CivilT_T"
+        />
+        <CreaterItem
+          :job="$t('systemsetting.info.technicalManager')"
+          :names="['txkodo']"
+          url="https://twitter.com/txkodo"
+        />
+        <CreaterItem :job="$t('systemsetting.info.support')" :names="['nozz']" />
+      </div>
     </div>
   </div>
 </template>


### PR DESCRIPTION
<!-- このPRはブランチを切った後，直ちに作成し，ブランチ内で変更する箇所を次章に列挙する -->

<!-- PRの作成時にはLabelsとAssignees（担当者）を割り当て，責任の所在を明確にする -->
<!-- PRの内容をすべて実装した際にReviewersを指定して，変更管理の承認を受ける -->

# 縦スクロールバーを追加

<!-- Pull Requestの概要を２行程度で説明する -->
<!-- このPRはブランチを切った後，直ちに作成し，ブランチ内で変更する箇所を次章に列挙する -->

システム設定における「共有設定」と「システム情報」タブに縦スクロールが定義されておらず，画面から見切れたコンテンツについては上タブと一緒にスクロールしてしまう問題が発生

これに対して，上タブを残したまま内容のみがスクロールするように修正した


## 承認者への申し送り事項
- 「ホーム」「プロパティ」「その他の設定」タブでも使用している`mainField`プロパティの設定を更新しています．コンテンツを描画する範囲を確定するプロパティのため，ウィンドウサイズを変更した際であってもコンテンツの描画範囲が以前と変わっていないことを確認してください