### PR TITLE
自動アップデートに際してダイアログを表示する

### DIFF
--- a/src-electron/api/api.ts
+++ b/src-electron/api/api.ts
@@ -62,9 +62,6 @@ export interface API extends IAPI {
     /** サーバー終了時のメッセージ */
     FinishServer: (world: WorldID) => void;
 
-    /** アップデートがある際の通知(実行中のOS以外の通知はこない) */
-    NotifySystemUpdate: (type: OsPlatform, systemVersion: string) => void;
-
     /** サーバー実行(前|後)の進捗画面表示 */
     Progress: (world: WorldID, progress: GroupProgress) => void;
 
@@ -90,6 +87,12 @@ export interface API extends IAPI {
      * false : ServerStarterの起動を継続し、シャットダウンしない
      */
     CheckShutdown: () => Promise<boolean>;
+
+    /** アップデートがある際の通知 戻り値はアップデートを実行するかどうか(Linuxの場合はfalse確定) */
+    NotifySystemUpdate: (
+      type: OsPlatform,
+      systemVersion: string
+    ) => Promise<boolean>;
   };
   sendWindowToMain: {
     /** 実行中のサーバーにコマンドを送る

--- a/src-electron/api/api.ts
+++ b/src-electron/api/api.ts
@@ -25,6 +25,7 @@ import {
   RemoteWorld,
 } from '../schema/remote';
 import { ServerStartNotification } from '../schema/server';
+import { OsPlatform } from '../util/os';
 
 /**
  * ## APIの利用方法
@@ -60,6 +61,9 @@ export interface API extends IAPI {
 
     /** サーバー終了時のメッセージ */
     FinishServer: (world: WorldID) => void;
+
+    /** アップデートがある際の通知(実行中のOS以外の通知はこない) */
+    NotifySystemUpdate: (type: OsPlatform, systemVersion: string) => void;
 
     /** サーバー実行(前|後)の進捗画面表示 */
     Progress: (world: WorldID, progress: GroupProgress) => void;

--- a/src-electron/api/api.ts
+++ b/src-electron/api/api.ts
@@ -73,6 +73,9 @@ export interface API extends IAPI {
 
     /** バックエンドプロセスで致命的でないエラーが起こった時に走る */
     Error: (error: ErrorMessage) => void;
+
+    /** アップデートがある際の通知 */
+    NotifySystemUpdate: (type: OsPlatform, systemVersion: string) => void;
   };
   invokeMainToWindow: {
     /** MinecraftEulaへの同意チェック */
@@ -87,12 +90,6 @@ export interface API extends IAPI {
      * false : ServerStarterの起動を継続し、シャットダウンしない
      */
     CheckShutdown: () => Promise<boolean>;
-
-    /** アップデートがある際の通知 戻り値はアップデートを実行するかどうか(Linuxの場合はfalse確定) */
-    NotifySystemUpdate: (
-      type: OsPlatform,
-      systemVersion: string
-    ) => Promise<boolean>;
   };
   sendWindowToMain: {
     /** 実行中のサーバーにコマンドを送る

--- a/src-electron/api/api.ts
+++ b/src-electron/api/api.ts
@@ -103,6 +103,9 @@ export interface API extends IAPI {
 
     /** pathをエクスプローラーで開く */
     OpenFolder: (path: string, autocreate: boolean) => Promise<Failable<void>>;
+
+    /** mainWindowが準備できた(App.vueのセットアップ処理が終わった)ときに発火 */
+    ReadyWindow: () => void;
   };
   invokeWindowToMain: {
     /** 実行中のサーバーを再起動 */

--- a/src-electron/core/api.ts
+++ b/src-electron/core/api.ts
@@ -2,8 +2,9 @@ import { API } from '../api/api';
 import { BackCaller } from '../ipc/link';
 
 /** バックエンドからで呼んでいいapi */
-export let api: BackCaller<API>;
+export const api = {} as BackCaller<API>;
 
 export function setBackAPI(_api: BackCaller<API>) {
-  api = _api;
+  api.invoke = _api.invoke;
+  api.send = _api.send;
 }

--- a/src-electron/core/user/launcher/launcherProfile.ts
+++ b/src-electron/core/user/launcher/launcherProfile.ts
@@ -52,7 +52,9 @@ function getLauncherPath(): Path {
     case 'mac-os':
     case 'mac-os-arm64':
       return homePath.child('Library/Application Support/minecraft/');
-    case 'linux':
+    case 'debian':
+      return homePath.child('.minecraft/');
+    case 'redhat':
       return homePath.child('.minecraft/');
   }
 }

--- a/src-electron/electron-main.ts
+++ b/src-electron/electron-main.ts
@@ -4,7 +4,7 @@ import { app, BrowserWindow, nativeTheme } from 'electron';
 import * as path from 'path';
 import * as os from 'os';
 import { setupIPC } from './ipc/setup';
-import { onQuit, onReadyWindow } from './lifecycle/lifecycle';
+import { onQuit } from './lifecycle/lifecycle';
 import { setServerStarterApp } from './lifecycle/exit';
 import { update } from './updater/updater';
 import { getSystemSettings, setSystemSettings } from './core/stores/system';
@@ -75,11 +75,6 @@ async function createWindow() {
 
   // フロントエンドとバックエンドの呼び出し処理をリンク
   setupIPC(() => mainWindow);
-
-  // windowの準備が終わったらイベントを発火
-  mainWindow.on('ready-to-show', () => {
-    onReadyWindow.invoke();
-  });
 }
 
 app.whenReady().then(createWindow);

--- a/src-electron/electron-main.ts
+++ b/src-electron/electron-main.ts
@@ -76,8 +76,10 @@ async function createWindow() {
   // フロントエンドとバックエンドの呼び出し処理をリンク
   setupIPC(() => mainWindow);
 
-  // windowの準備が終わったのでイベント発火
-  await onReadyWindow.invoke();
+  // windowの準備が終わったらイベントを発火
+  mainWindow.on('ready-to-show', () => {
+    onReadyWindow.invoke();
+  });
 }
 
 app.whenReady().then(createWindow);

--- a/src-electron/electron-main.ts
+++ b/src-electron/electron-main.ts
@@ -4,7 +4,7 @@ import { app, BrowserWindow, nativeTheme } from 'electron';
 import * as path from 'path';
 import * as os from 'os';
 import { setupIPC } from './ipc/setup';
-import { onQuit } from './lifecycle/lifecycle';
+import { onQuit, onReadyWindow } from './lifecycle/lifecycle';
 import { setServerStarterApp } from './lifecycle/exit';
 import { update } from './updater/updater';
 import { getSystemSettings, setSystemSettings } from './core/stores/system';
@@ -75,6 +75,9 @@ async function createWindow() {
 
   // フロントエンドとバックエンドの呼び出し処理をリンク
   setupIPC(() => mainWindow);
+
+  // windowの準備が終わったのでイベント発火
+  await onReadyWindow.invoke();
 }
 
 app.whenReady().then(createWindow);

--- a/src-electron/electron-preload.ts
+++ b/src-electron/electron-preload.ts
@@ -91,6 +91,7 @@ const api: FrontAPI = {
   onProgress: on('Progress'),
   onAddConsole: on('AddConsole'),
   onError: on('Error'),
+  onNotifySystemUpdate: on('NotifySystemUpdate'),
 
   // HANDLE
   handleNotifySystemUpdate: send('NotifySystemUpdate'),

--- a/src-electron/electron-preload.ts
+++ b/src-electron/electron-preload.ts
@@ -102,6 +102,7 @@ const api: FrontAPI = {
   sendCommand: send('Command'),
   sendOpenBrowser: send('OpenBrowser'),
   sendOpenFolder: send('OpenFolder'),
+  sendReadyWindow: send('ReadyWindow'),
 
   // INVOKE
   invokeReboot: invoke('Reboot'),

--- a/src-electron/electron-preload.ts
+++ b/src-electron/electron-preload.ts
@@ -86,6 +86,7 @@ function handle<C extends string>(
 
 const api: FrontAPI = {
   // ON
+  onNotifySystemUpdate: send('NotifySystemUpdate'),
   onStartServer: on('StartServer'),
   onFinishServer: on('FinishServer'),
   onProgress: on('Progress'),

--- a/src-electron/electron-preload.ts
+++ b/src-electron/electron-preload.ts
@@ -86,7 +86,6 @@ function handle<C extends string>(
 
 const api: FrontAPI = {
   // ON
-  onNotifySystemUpdate: send('NotifySystemUpdate'),
   onStartServer: on('StartServer'),
   onFinishServer: on('FinishServer'),
   onProgress: on('Progress'),
@@ -94,6 +93,7 @@ const api: FrontAPI = {
   onError: on('Error'),
 
   // HANDLE
+  handleNotifySystemUpdate: send('NotifySystemUpdate'),
   handleAgreeEula: handle('AgreeEula'),
   handleCheckShutdown: handle('CheckShutdown'),
 

--- a/src-electron/ipc/back.ts
+++ b/src-electron/ipc/back.ts
@@ -32,6 +32,7 @@ import {
   validateNewRemoteWorldName,
   validateRemoteSetting,
 } from '../core/remote/remote';
+import { readyWindow } from '../lifecycle/lifecycle';
 export const getBackListener = (
   windowGetter: () => BrowserWindow | undefined
 ): BackListener<API> => ({
@@ -39,6 +40,7 @@ export const getBackListener = (
     Command: runCommand,
     OpenBrowser: openBrowser,
     OpenFolder: openFolder,
+    ReadyWindow: readyWindow,
   },
   handle: {
     Reboot: reboot,

--- a/src-electron/ipc/front.ts
+++ b/src-electron/ipc/front.ts
@@ -61,11 +61,11 @@ export function getFrontAPIListener(
       Progress: send('Progress', window),
       AddConsole: send('AddConsole', window),
       Error: send('Error', window),
+      NotifySystemUpdate: send('NotifySystemUpdate', window),
     },
     handle: {
       AgreeEula: invoke('AgreeEula', window),
       CheckShutdown: invoke('CheckShutdown', window),
-      NotifySystemUpdate: invoke('NotifySystemUpdate', window),
     },
   };
   return result;

--- a/src-electron/ipc/front.ts
+++ b/src-electron/ipc/front.ts
@@ -56,7 +56,6 @@ export function getFrontAPIListener(
 ): FrontListener<API> {
   const result: ChanneledFrontListener<FrontListener<API>> = {
     on: {
-      NotifySystemUpdate: send('NotifySystemUpdate', window),
       StartServer: send('StartServer', window),
       FinishServer: send('FinishServer', window),
       Progress: send('Progress', window),
@@ -66,6 +65,7 @@ export function getFrontAPIListener(
     handle: {
       AgreeEula: invoke('AgreeEula', window),
       CheckShutdown: invoke('CheckShutdown', window),
+      NotifySystemUpdate: invoke('NotifySystemUpdate', window),
     },
   };
   return result;

--- a/src-electron/ipc/front.ts
+++ b/src-electron/ipc/front.ts
@@ -56,6 +56,7 @@ export function getFrontAPIListener(
 ): FrontListener<API> {
   const result: ChanneledFrontListener<FrontListener<API>> = {
     on: {
+      NotifySystemUpdate: send('NotifySystemUpdate', window),
       StartServer: send('StartServer', window),
       FinishServer: send('FinishServer', window),
       Progress: send('Progress', window),

--- a/src-electron/lifecycle/lifecycle.ts
+++ b/src-electron/lifecycle/lifecycle.ts
@@ -3,6 +3,9 @@ import { createAppEvent } from './event';
 /** electronのwillQuitイベント(すべてのwindowが閉じた後の処理)で発火されるイベント */
 export const onQuit = createAppEvent();
 
+/** electronのwillQuitイベント(すべてのwindowが閉じた後の処理)で発火されるイベント */
+export const onReadyWindow = createAppEvent();
+
 /**
  * 非同期処理の途中でアプリケーションが閉じられても、処理の終了を保証する
  *

--- a/src-electron/lifecycle/lifecycle.ts
+++ b/src-electron/lifecycle/lifecycle.ts
@@ -19,3 +19,7 @@ export async function assertComplete<T>(promise: Promise<T>) {
   dispatch();
   return result;
 }
+
+export function readyWindow() {
+  onReadyWindow.invoke();
+}

--- a/src-electron/updater/fetch.ts
+++ b/src-electron/updater/fetch.ts
@@ -32,7 +32,8 @@ export async function getLatestRelease(
 
 function parseAssets(assets: ReleaseAsset[], osPLatform: OsPlatform) {
   const suffix = {
-    linux: '.AppImage',
+    redhat: '.rpm',
+    debian: '.deb',
     'mac-os': '.pkg',
     'mac-os-arm64': '.pkg',
     'windows-x64': '.msi',

--- a/src-electron/updater/notify.ts
+++ b/src-electron/updater/notify.ts
@@ -1,0 +1,10 @@
+import { api } from 'app/src-electron/core/api';
+import { OsPlatform } from 'app/src-electron/util/os';
+
+/** linuxの最新版があることを通知 */
+export const notifyUpdate = async (
+  type: OsPlatform,
+  systemVersion: string
+): Promise<void> => {
+  await api.send.NotifySystemUpdate(type, systemVersion);
+};

--- a/src-electron/updater/notify.ts
+++ b/src-electron/updater/notify.ts
@@ -1,10 +1,11 @@
 import { api } from 'app/src-electron/core/api';
 import { OsPlatform } from 'app/src-electron/util/os';
+import { onReadyWindow } from '../lifecycle/lifecycle';
 
-/** linuxの最新版があることを通知 */
+/** linuxの最新版があることをwindowが生成されてから通知 */
 export const notifyUpdate = async (
   type: OsPlatform,
   systemVersion: string
 ): Promise<void> => {
-  await api.send.NotifySystemUpdate(type, systemVersion);
+  onReadyWindow(() => api.send.NotifySystemUpdate(type, systemVersion), true);
 };

--- a/src-electron/updater/updater.ts
+++ b/src-electron/updater/updater.ts
@@ -65,8 +65,6 @@ export async function update() {
       await installMac(update.url, PAT);
       break;
     case 'debian':
-      await notifyUpdate(osPlatform, vLessVersion);
-      break;
     case 'redhat':
       await notifyUpdate(osPlatform, vLessVersion);
       break;

--- a/src-electron/util/java/java.ts
+++ b/src-electron/util/java/java.ts
@@ -1,7 +1,7 @@
 import { runtimePath } from '../../core/const';
 import { versionConfig } from '../../core/stores/config';
 import { BytesData } from '../bytesData';
-import { osPlatform } from '../os';
+import { OsPlatform, osPlatform } from '../os';
 import { Path } from '../path';
 import { Failable } from '../error/failable';
 import { installManifest, Manifest } from './manifest';
@@ -29,9 +29,18 @@ export async function readyJava(
 
   const json = await getAllJson();
 
+  const allJsonKeyOsPlatformMap: Record<OsPlatform, keyof AllJson> = {
+    debian: 'linux',
+    redhat: 'linux',
+    'mac-os': 'mac-os',
+    'mac-os-arm64': 'mac-os-arm64',
+    'windows-x64': 'windows-x64',
+  };
+
   if (isError(json)) return json;
 
-  const manifest = json[osPlatform][component][0].manifest;
+  const manifest =
+    json[allJsonKeyOsPlatformMap[osPlatform]][component][0].manifest;
 
   const path = runtimePath.child(`${component}/${osPlatform}`);
 
@@ -42,7 +51,8 @@ export async function readyJava(
   switch (osPlatform) {
     case 'windows-x64':
       return javaw ? path.child('bin/javaw.exe') : path.child('bin/java.exe');
-    case 'linux':
+    case 'debian':
+    case 'redhat':
       return path.child('bin/java');
     case 'mac-os':
     case 'mac-os-arm64':

--- a/src-electron/util/os.ts
+++ b/src-electron/util/os.ts
@@ -37,18 +37,46 @@ function getOsPlatform(): OsPlatform {
 import { execSync } from 'child_process';
 
 function getLinuxType() {
-  // Execute the command to check the distribution
-  const command = 'cat /etc/os-release | grep "ID_LIKE"';
+  // ID_LIKEをとってくる
+  try {
+    const idLikeCommand = 'cat /etc/os-release | grep "^ID_LIKE="';
+    const outstr = execSync(idLikeCommand, { encoding: 'utf-8' });
+    // Parse the output to determine the Linux type
+    if (outstr.includes('debian')) {
+      return 'debian';
+    } else if (outstr.includes('rhel')) {
+      return 'redhat';
+    } else {
+      return undefined;
+    }
+  } catch {
+    // ID_LIKEがとれなかったらIDをとってくる
+    // OSごとに取ってるので追加する可能性あり
 
-  const outstr = execSync(command, { encoding: 'utf-8' });
+    // Execute the command to check the distribution
+    const command = 'cat /etc/os-release | grep "^ID="';
 
-  // Parse the output to determine the Linux type
-  if (outstr.includes('debian')) {
-    return 'debian';
-  } else if (outstr.includes('rhel')) {
-    return 'redhat';
-  } else {
-    return undefined;
+    try {
+      const outstr = execSync(command, { encoding: 'utf-8' });
+      const idMatch = outstr.match(/(?:^|\n)ID\s*=(.*)\s*/);
+      if (idMatch === null) return idMatch;
+      const id = idMatch[1];
+
+      switch (id) {
+        case 'rhel': // Red Hat Enterprise Linux
+        case 'centos': // CentOS/CentOS Stream
+        case 'ol': // Oracle Linux
+        case 'amzn': // Amazon Linux
+        case 'almalinux': // Almalinux
+          return 'redhat';
+        case 'ubuntu': // Ubuntu
+          return 'debian';
+        default:
+          return undefined;
+      }
+    } catch {
+      return undefined;
+    }
   }
 }
 

--- a/src-electron/util/os.ts
+++ b/src-electron/util/os.ts
@@ -1,4 +1,9 @@
-export type OsPlatform = 'linux' | 'mac-os' | 'mac-os-arm64' | 'windows-x64';
+export type OsPlatform =
+  | 'debian'
+  | 'redhat'
+  | 'mac-os'
+  | 'mac-os-arm64'
+  | 'windows-x64';
 
 function getOsPlatform(): OsPlatform {
   const platform = process.platform;
@@ -15,9 +20,35 @@ function getOsPlatform(): OsPlatform {
 
     //linux
     case 'linux':
-      return 'linux';
+      const linuxType = getLinuxType();
+      switch (linuxType) {
+        case 'debian':
+          return 'debian';
+        case 'redhat':
+          return 'redhat';
+        default:
+          throw new Error('unknown linux distribution');
+      }
     default:
       throw new Error(`${platform} is unavailable os platform`);
+  }
+}
+
+import { execSync } from 'child_process';
+
+function getLinuxType() {
+  // Execute the command to check the distribution
+  const command = 'cat /etc/os-release | grep "ID_LIKE"';
+
+  const outstr = execSync(command, { encoding: 'utf-8' });
+
+  // Parse the output to determine the Linux type
+  if (outstr.includes('debian')) {
+    return 'debian';
+  } else if (outstr.includes('rhel')) {
+    return 'redhat';
+  } else {
+    return undefined;
   }
 }
 

--- a/src-electron/util/os.ts
+++ b/src-electron/util/os.ts
@@ -47,7 +47,7 @@ function getLinuxType() {
     } else if (outstr.includes('rhel')) {
       return 'redhat';
     } else {
-      return undefined;
+      throw new Error('unknown linux distribution');
     }
   } catch {
     // ID_LIKEがとれなかったらIDをとってくる
@@ -68,6 +68,7 @@ function getLinuxType() {
         case 'ol': // Oracle Linux
         case 'amzn': // Amazon Linux
         case 'almalinux': // Almalinux
+        case 'fedora': // fedora
           return 'redhat';
         case 'ubuntu': // Ubuntu
           return 'debian';

--- a/src-electron/util/shutdown.ts
+++ b/src-electron/util/shutdown.ts
@@ -9,7 +9,8 @@ export function shutdown() {
     case 'mac-os':
     case 'mac-os-arm64':
       return shutdownMac();
-    case 'linux':
+    case 'debian':
+    case 'redhat':
       return shutdownLinux();
   }
 }

--- a/src/App.vue
+++ b/src/App.vue
@@ -76,9 +76,10 @@ window.API.onNotifySystemUpdate((_event, os, newVer) => {
       os: os,
       newVer: newVer,
     } as UpdateNotifyProp,
-  })
-  .onOk(() => {
-    window.API.sendOpenBrowser('https://server-starter-for-minecraft.github.io')
+  }).onOk(() => {
+    window.API.sendOpenBrowser(
+      'https://server-starter-for-minecraft.github.io'
+    );
   });
 });
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -24,6 +24,12 @@ import { deepCopy } from './scripts/deepCopy';
 import { setColor } from './color';
 import ErrorDialogView from './components/Error/ErrorDialogView.vue';
 import EulaDialog from 'src/components/Progress/EulaDialog.vue';
+import UpdateNotifyDialog from './components/App/UpdateNotify/UpdateNotifyDialog.vue';
+import {
+  UpdateNotifyProp,
+  setUpdateHandler,
+  updateSelecter,
+} from './components/App/UpdateNotify/iUpdateNotifyDialog';
 
 const sysStore = useSystemStore();
 const mainStore = useMainStore();
@@ -66,6 +72,45 @@ window.API.onFinishServer((_event, worldID) => {
 window.API.onAddConsole((_event, worldID, chunk, isError) => {
   consoleStore.setConsole(worldID, chunk, isError);
 });
+
+// アップデートを実行するときに確認のダイアログを表示する
+// window.API.handleUpdateSystem(
+//   async (_: Electron.IpcRendererEvent, os, required) => {
+//     const promise = new Promise<boolean>((resolve) => {
+//       setUpdateHandler(resolve);
+//     });
+
+//     $q.dialog({
+//       component: UpdateNotifyDialog,
+//       componentProps: {
+//         os: os,
+//         required: required,
+//       } as UpdateNotifyProp,
+//     })
+//       .onOk(() => {
+//         updateSelecter(true);
+//       })
+//       .onCancel(() => {
+//         updateSelecter(false);
+//       });
+
+//       return await promise
+//   }
+// );
+// TODO: 上記が作動したら下記のダイアログは削除
+$q.dialog({
+  component: UpdateNotifyDialog,
+  componentProps: {
+    os: 'windows',
+    required: false,
+  } as UpdateNotifyProp,
+})
+  .onOk(() => {
+    console.log('TRUE');
+  })
+  .onCancel(() => {
+    console.log('FALSE');
+  });
 // Eulaの同意処理
 window.API.handleAgreeEula(
   async (_: Electron.IpcRendererEvent, worldID, url) => {

--- a/src/App.vue
+++ b/src/App.vue
@@ -19,17 +19,13 @@ import {
 } from 'src/stores/WorldTabs/PlayerStore';
 import { checkError, setOpenDialogFunc } from 'src/components/Error/Error';
 import { setShutdownHandler } from './components/SystemSettings/General/AutoShutdown/AutoShutdown';
+import { UpdateNotifyProp } from './components/App/UpdateNotify/iUpdateNotifyDialog';
 import { EulaDialogProp } from 'src/components/Progress/iEulaDialog';
 import { deepCopy } from './scripts/deepCopy';
 import { setColor } from './color';
 import ErrorDialogView from './components/Error/ErrorDialogView.vue';
 import EulaDialog from 'src/components/Progress/EulaDialog.vue';
 import UpdateNotifyDialog from './components/App/UpdateNotify/UpdateNotifyDialog.vue';
-import {
-  UpdateNotifyProp,
-  setUpdateHandler,
-  updateSelecter,
-} from './components/App/UpdateNotify/iUpdateNotifyDialog';
 
 const sysStore = useSystemStore();
 const mainStore = useMainStore();
@@ -72,45 +68,20 @@ window.API.onFinishServer((_event, worldID) => {
 window.API.onAddConsole((_event, worldID, chunk, isError) => {
   consoleStore.setConsole(worldID, chunk, isError);
 });
-
 // アップデートを実行するときに確認のダイアログを表示する
-// window.API.handleUpdateSystem(
-//   async (_: Electron.IpcRendererEvent, os, required) => {
-//     const promise = new Promise<boolean>((resolve) => {
-//       setUpdateHandler(resolve);
-//     });
-
-//     $q.dialog({
-//       component: UpdateNotifyDialog,
-//       componentProps: {
-//         os: os,
-//         required: required,
-//       } as UpdateNotifyProp,
-//     })
-//       .onOk(() => {
-//         updateSelecter(true);
-//       })
-//       .onCancel(() => {
-//         updateSelecter(false);
-//       });
-
-//       return await promise
-//   }
-// );
-// TODO: 上記が作動したら下記のダイアログは削除
-$q.dialog({
-  component: UpdateNotifyDialog,
-  componentProps: {
-    os: 'windows',
-    required: false,
-  } as UpdateNotifyProp,
-})
-  .onOk(() => {
-    console.log('TRUE');
+window.API.onNotifySystemUpdate((_event, os, newVer) => {
+  $q.dialog({
+    component: UpdateNotifyDialog,
+    componentProps: {
+      os: os,
+      newVer: newVer,
+    } as UpdateNotifyProp,
   })
-  .onCancel(() => {
-    console.log('FALSE');
+  .onOk(() => {
+    window.API.sendOpenBrowser('https://server-starter-for-minecraft.github.io')
   });
+});
+
 // Eulaの同意処理
 window.API.handleAgreeEula(
   async (_: Electron.IpcRendererEvent, worldID, url) => {

--- a/src/App.vue
+++ b/src/App.vue
@@ -171,6 +171,9 @@ function setSubscribe() {
 
   setPlayerSearchSubscriber(playerStore);
 }
+
+// App.vueでの初期化処理がすべて終わったことを通知
+window.API.sendReadyWindow();
 </script>
 
 <template>

--- a/src/components/App/UpdateNotify/UpdateNotifyDialog.vue
+++ b/src/components/App/UpdateNotify/UpdateNotifyDialog.vue
@@ -36,7 +36,7 @@ const tmp = ref(true);
       </template>
       <div v-if="isAutoUpdate" style="font-size: 0.8rem; opacity: 0.6">
         ServerStarter2のアップデートを開始します<br />
-        最新版のServerStarter2を使ってより快適にマルチプレイを楽しみましょう！<br><br>
+        最新版のServerStarter2を使ってより快適にマルチプレイを楽しみましょう！<br /><br />
         ※アップデート後にこの画面が繰り返し表示される場合は，<ssA
           url="https://server-starter-for-minecraft.github.io"
           >公式HP</ssA

--- a/src/components/App/UpdateNotify/UpdateNotifyDialog.vue
+++ b/src/components/App/UpdateNotify/UpdateNotifyDialog.vue
@@ -1,0 +1,58 @@
+<script setup lang="ts">
+import { useDialogPluginComponent } from 'quasar';
+import { UpdateNotifyProp } from './iUpdateNotifyDialog';
+import { useSystemStore } from 'src/stores/SystemStore';
+import SsBtn from 'src/components/util/base/ssBtn.vue';
+import BaseDialogCard from 'src/components/util/baseDialog/baseDialogCard.vue';
+import ssA from 'src/components/util/base/ssA.vue';
+import { ref } from 'vue';
+
+defineEmits({ ...useDialogPluginComponent.emitsObject });
+const { dialogRef, onDialogHide, onDialogCancel, onDialogOK } =
+  useDialogPluginComponent();
+const prop = defineProps<UpdateNotifyProp>();
+
+const isAutoUpdate = prop.os !== 'linux';
+
+const sysStore = useSystemStore();
+const tmp = ref(true);
+</script>
+
+<template>
+  <q-dialog ref="dialogRef" persistent @hide="onDialogHide">
+    <BaseDialogCard
+      title="最新版へアップデート"
+      :ok-btn-txt="
+        isAutoUpdate ? 'アップデートを開始する' : 'インストーラーをダウンロード'
+      "
+      @ok-click="onDialogOK"
+    >
+      <template #additionalBtns>
+        <SsBtn
+          v-if="!required"
+          label="アップデートを行わない"
+          @click="onDialogCancel"
+        />
+      </template>
+      <div v-if="isAutoUpdate" style="font-size: 0.8rem; opacity: 0.6">
+        ServerStarter2のアップデートを開始します<br />
+        最新版のServerStarter2を使ってより快適にマルチプレイを楽しみましょう！<br><br>
+        ※アップデート後にこの画面が繰り返し表示される場合は，<ssA
+          url="https://server-starter-for-minecraft.github.io"
+          >公式HP</ssA
+        >より再インストールをお願いします！
+      </div>
+      <div v-else style="font-size: 0.8rem; opacity: 0.6">
+        ServerStarter2の最新版が新しくリリースされました！<br />
+        最新のインストーラーをダウンロードし，新しいServerStarter2を手に入れましょう！
+      </div>
+      <!-- TODO: `sysStore.systemSettings.user.rejectUpdateNotify`に差し替える -->
+      <q-checkbox
+        v-if="!required"
+        v-model="tmp"
+        label="次の最新版がリリースされるまでこの通知を表示しない"
+        class="q-pt-md"
+      />
+    </BaseDialogCard>
+  </q-dialog>
+</template>

--- a/src/components/App/UpdateNotify/UpdateNotifyDialog.vue
+++ b/src/components/App/UpdateNotify/UpdateNotifyDialog.vue
@@ -1,58 +1,26 @@
 <script setup lang="ts">
 import { useDialogPluginComponent } from 'quasar';
 import { UpdateNotifyProp } from './iUpdateNotifyDialog';
-import { useSystemStore } from 'src/stores/SystemStore';
-import SsBtn from 'src/components/util/base/ssBtn.vue';
 import BaseDialogCard from 'src/components/util/baseDialog/baseDialogCard.vue';
-import ssA from 'src/components/util/base/ssA.vue';
-import { ref } from 'vue';
 
 defineEmits({ ...useDialogPluginComponent.emitsObject });
-const { dialogRef, onDialogHide, onDialogCancel, onDialogOK } =
-  useDialogPluginComponent();
-const prop = defineProps<UpdateNotifyProp>();
-
-const isAutoUpdate = prop.os !== 'linux';
-
-const sysStore = useSystemStore();
-const tmp = ref(true);
+const { dialogRef, onDialogHide, onDialogOK } = useDialogPluginComponent();
+defineProps<UpdateNotifyProp>();
 </script>
 
 <template>
   <q-dialog ref="dialogRef" persistent @hide="onDialogHide">
     <BaseDialogCard
-      title="最新版へアップデート"
-      :ok-btn-txt="
-        isAutoUpdate ? 'アップデートを開始する' : 'インストーラーをダウンロード'
-      "
+      :title="$t('updater.title')"
+      :ok-btn-txt="$t('updater.btn')"
       @ok-click="onDialogOK"
     >
-      <template #additionalBtns>
-        <SsBtn
-          v-if="!required"
-          label="アップデートを行わない"
-          @click="onDialogCancel"
-        />
-      </template>
-      <div v-if="isAutoUpdate" style="font-size: 0.8rem; opacity: 0.6">
-        ServerStarter2のアップデートを開始します<br />
-        最新版のServerStarter2を使ってより快適にマルチプレイを楽しみましょう！<br /><br />
-        ※アップデート後にこの画面が繰り返し表示される場合は，<ssA
-          url="https://server-starter-for-minecraft.github.io"
-          >公式HP</ssA
-        >より再インストールをお願いします！
+      <div
+        class="fit"
+        style="font-size: 0.8rem; opacity: 0.6; white-space: pre-line"
+      >
+        {{ $t('updater.desc', { newVer: newVer }) }}
       </div>
-      <div v-else style="font-size: 0.8rem; opacity: 0.6">
-        ServerStarter2の最新版が新しくリリースされました！<br />
-        最新のインストーラーをダウンロードし，新しいServerStarter2を手に入れましょう！
-      </div>
-      <!-- TODO: `sysStore.systemSettings.user.rejectUpdateNotify`に差し替える -->
-      <q-checkbox
-        v-if="!required"
-        v-model="tmp"
-        label="次の最新版がリリースされるまでこの通知を表示しない"
-        class="q-pt-md"
-      />
     </BaseDialogCard>
   </q-dialog>
 </template>

--- a/src/components/App/UpdateNotify/iUpdateNotifyDialog.ts
+++ b/src/components/App/UpdateNotify/iUpdateNotifyDialog.ts
@@ -1,25 +1,6 @@
-let selecter: ((value: boolean) => void) | undefined;
+import { OsPlatform } from "app/src-electron/util/os";
 
 export interface UpdateNotifyProp {
-  os: 'windows' | 'macOS' | 'linux';
-  required?: boolean;
-}
-
-/**
- * バックエンドからの通信を待機し，要求があった場合は選択内容を返却する
- */
-export function setUpdateHandler(
-  resolve: (value: boolean | PromiseLike<boolean>) => void
-) {
-  selecter = (value: boolean) => {
-    selecter = undefined;
-    resolve(value);
-  };
-}
-
-/**
- * 選択内容を指定する
- */
-export function updateSelecter(select: boolean) {
-  selecter?.(select);
+  os: OsPlatform;
+  newVer: string;
 }

--- a/src/components/App/UpdateNotify/iUpdateNotifyDialog.ts
+++ b/src/components/App/UpdateNotify/iUpdateNotifyDialog.ts
@@ -1,0 +1,25 @@
+let selecter: ((value: boolean) => void) | undefined;
+
+export interface UpdateNotifyProp {
+  os: 'windows' | 'macOS' | 'linux';
+  required?: boolean;
+}
+
+/**
+ * バックエンドからの通信を待機し，要求があった場合は選択内容を返却する
+ */
+export function setUpdateHandler(
+  resolve: (value: boolean | PromiseLike<boolean>) => void
+) {
+  selecter = (value: boolean) => {
+    selecter = undefined;
+    resolve(value);
+  };
+}
+
+/**
+ * 選択内容を指定する
+ */
+export function updateSelecter(select: boolean) {
+  selecter?.(select);
+}

--- a/src/components/App/UpdateNotify/iUpdateNotifyDialog.ts
+++ b/src/components/App/UpdateNotify/iUpdateNotifyDialog.ts
@@ -1,4 +1,4 @@
-import { OsPlatform } from "app/src-electron/util/os";
+import { OsPlatform } from 'app/src-electron/util/os';
 
 export interface UpdateNotifyProp {
   os: OsPlatform;

--- a/src/i18n/en-US/Dialogs/updater.ts
+++ b/src/i18n/en-US/Dialogs/updater.ts
@@ -1,0 +1,9 @@
+import { MessageSchema } from 'src/boot/i18n';
+
+export const enUSUpdater: MessageSchema['updater'] = {
+  title: 'New ServerStarter2 is released now!',
+  btn: 'Open the web page',
+  desc: '\
+    ServerStarter2 ({newVer}) is released！\n\
+    Please get the latest installer from the web page, and try out NEW features!'
+};

--- a/src/i18n/en-US/Dialogs/updater.ts
+++ b/src/i18n/en-US/Dialogs/updater.ts
@@ -5,5 +5,5 @@ export const enUSUpdater: MessageSchema['updater'] = {
   btn: 'Open the web page',
   desc: '\
     ServerStarter2 ({newVer}) is released！\n\
-    Please get the latest installer from the web page, and try out NEW features!'
+    Please get the latest installer from the web page, and try out NEW features!',
 };

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -11,6 +11,7 @@ import { enUSProgress } from './Pages/World/progress';
 import { enUSMainLayout } from './Pages/mainLayout';
 import { enUSIcon } from './Dialogs/icon';
 import { enUSShareWorld } from './Pages/World/shareWorld';
+import { enUSUpdater } from './Dialogs/updater';
 import { enWelcome } from './Dialogs/welcome';
 import { enAutoShutdown } from './Dialogs/autoshutdown';
 import { enUSGeneral } from './Other/general';
@@ -34,6 +35,7 @@ export const enUS: MessageSchema = {
   mainLayout: enUSMainLayout,
   icon: enUSIcon,
   shareWorld: enUSShareWorld,
+  updater: enUSUpdater,
   welcome: enWelcome,
   autoshutdown: enAutoShutdown,
   eulaDialog: enUSEulaDialog,

--- a/src/i18n/ja/Dialogs/updater.ts
+++ b/src/i18n/ja/Dialogs/updater.ts
@@ -1,0 +1,7 @@
+export const jaUpdater = {
+  title: '最新版へアップデート',
+  btn: 'ダウンロードページを開く',
+  desc: '\
+    ServerStarter2の最新版({newVer})が新しくリリースされました！\n\
+    最新のインストーラーをダウンロードし，新しいServerStarter2を手に入れましょう！'
+};

--- a/src/i18n/ja/Dialogs/updater.ts
+++ b/src/i18n/ja/Dialogs/updater.ts
@@ -3,5 +3,5 @@ export const jaUpdater = {
   btn: 'ダウンロードページを開く',
   desc: '\
     ServerStarter2の最新版({newVer})が新しくリリースされました！\n\
-    最新のインストーラーをダウンロードし，新しいServerStarter2を手に入れましょう！'
+    最新のインストーラーをダウンロードし，新しいServerStarter2を手に入れましょう！',
 };

--- a/src/i18n/ja/index.ts
+++ b/src/i18n/ja/index.ts
@@ -10,6 +10,7 @@ import { jaProgress } from './Pages/World/progress';
 import { jaMainLayout } from './Pages/mainLayout';
 import { jaIcon } from './Dialogs/icon';
 import { jaShareWorld } from './Pages/World/shareWorld';
+import { jaUpdater } from './Dialogs/updater';
 import { jaWelcome } from './Dialogs/welcome';
 import { jaAutoShutdown } from './Dialogs/autoshutdown';
 import { jaGeneral } from './Other/general';
@@ -33,6 +34,7 @@ export const ja = {
   mainLayout: jaMainLayout,
   icon: jaIcon,
   shareWorld: jaShareWorld,
+  updater: jaUpdater,
   welcome: jaWelcome,
   autoshutdown: jaAutoShutdown,
   eulaDialog: jaEulaDialog,


### PR DESCRIPTION
<!-- このPRはブランチを切った後，直ちに作成し，ブランチ内で変更する箇所を次章に列挙する -->

<!-- PRの作成時にはLabelsとAssignees（担当者）を割り当て，責任の所在を明確にする -->
<!-- PRの内容をすべて実装した際にReviewersを指定して，変更管理の承認を受ける -->

# アップデートダイアログの追加

<!-- Pull Requestの概要を２行程度で説明する -->
<!-- このPRはブランチを切った後，直ちに作成し，ブランチ内で変更する箇所を次章に列挙する -->

自動アップデートを行う際にアップデートを行う旨をユーザーに通知し，ユーザーがアップデートの要否を選択できるようにする
Linux版では自動アップデートができないため，当該ダイアログの表示によって新バージョンリリースをユーザーに通知する

### Linux版での表示
![image](https://github.com/Server-Starter-for-Minecraft/ServerStarter2/assets/89191801/991faa8c-02c9-4b12-8955-2087c80078f7)

### その他OS版での表示
![image](https://github.com/Server-Starter-for-Minecraft/ServerStarter2/assets/89191801/19c17474-492a-4161-9b70-5ced812a11c2)

### アップデートを強制しない場合の表示
![image](https://github.com/Server-Starter-for-Minecraft/ServerStarter2/assets/89191801/bfba539e-5abf-48c6-8d3d-a95261e0e91e)


## 変更箇所
<!-- 変更内容を列挙し，小項目は必要に応じて利用する -->
<!-- Issuesから引用する際には「#00 を修正」のように記載し，Developmentに当該Issueを忘れずに登録する -->
- [x] OS，アップデート強制要否に応じたダイアログの作成
- [x] ダイアログテキストの翻訳
- [x] 本機能のバックエンド実装
- [x] バックエンド実装をフロントエンドに反映


## バックエンドとの通信内容
- バックエンドからアップデート可否の確認要求を飛ばし，フロントエンドでユーザーにアップデート要否を問い合わせ，その結果をバックエンドに戻す
- このため，Eulaと同様の構造を想定しフロントエンドは`handleUpdateSystem(os, required)`で通信待機する
  - `required: boolean`は，強制的なアップデートが必要か，アップデートの要否をユーザー判断にゆだねるかをバックエンドから指示する
  - `os: 'windows' | 'macOS' | 'linux'`は，利用中のOSの情報を指示する
- `SystemSettings.user.rejectUpdateNotify`を追加する．
  - 型は`boolean` (Default: False)
  - Trueの時にはアップデート先があってもアップデートを行わない＆確認ダイアログを表示しない
  - Falseの時にはアップデート先がある場合，確認ダイアログを表示する
  - `rejectUpdateNotify`がTrueであっても，次のバージョンアップが来たときにはFalseに書き換える機構が必要
    例えば，2.1.0のアップデートのリリース時にダイアログ上で`rejectUpdateNotify`がTrueにされた際には，以降2.1.0にはアップデートを行わずに，ダイアログが表示されない．
    その後，2.1.1がリリースされた際には`rejectUpdateNotify`を強制的にFalseに書き換えて，ダイアログが表示されるようにする
- バックエンドには`boolean`を戻し，Trueの時にはアップデートを行う，Falseの時にはアップデートを行わない，とする
- Linuxにおいてインストーラーのダウンロードボタンを押した場合は公式HPを開きつつ，システムを終了する
  - ブラウザの起動とシステムの終了処理はバックエンドで実装？