### PR TITLE
linuxのビルド版にアイコンを設定する

### DIFF
--- a/quasar.config.js
+++ b/quasar.config.js
@@ -239,6 +239,8 @@ module.exports = configure(function (/* ctx */) {
         },
         linux: {
           target: ['AppImage', 'deb', 'rpm'],
+          icon: path.join(__dirname, 'src-electron/icons'),
+          category: 'Utility',
         },
       },
     },


### PR DESCRIPTION
#135 に対応し、linuxのビルド版にアイコンを設定しました。

インストールに成功するとアイコンが反映されます。

Ubuntsのインストール画面には相変わらず歯車のアイコンが表示されますが、VScodeのインストールでも同じ挙動なので問題ありません。

# デバッグ依頼
- [x] deb形式のビルドでアイコンが反映されることを確認
- [x] rpm形式のビルドでアイコンが反映されることを確認