### PR TITLE
ビルドスクリプトを更新

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       # package.jsonのversionを次のバージョンに更新
       - uses: Server-Starter-for-Minecraft/VersionUpdater@v1
@@ -41,16 +43,33 @@ jobs:
         with:
           update-type: ${{inputs.type}}
 
-      # git commit
-      - name: git add & git commit
+      # git config
+      - name: git config
         run: |
           git config --local user.name github-actions[bot]
           git config --local user.email 41898282+github-actions[bot]@users.noreply.github.com
+
+      # リリースブランチの存在確認
+      # https://dev.classmethod.jp/articles/github-actions-check-if-specific-branch-is-existing/
+      - name: check release branch exists
+        run: |
+          branch_exists=$(
+            git fetch origin release/v${{steps.get_version.outputs.next-version}} &&
+            echo true ||
+            echo false
+          )
+          echo "BRANCH_EXISTS=${branch_exists}" >> $GITHUB_ENV
+
+      # git commit [リリースブランチがない場合]
+      - name: git add & git commit
+        if: env.BRANCH_EXISTS == 'false'
+        run: |
           git add .
           git commit -m "🔖 Release ${{ steps.get_version.outputs.next-version }}"
 
-      # mainに対してpullRequestを作成
+      # mainに対してpullRequestを作成 [リリースブランチがない場合]
       - name: Create Pull Request
+        if: env.BRANCH_EXISTS == 'false'
         id: pullrequest
         uses: peter-evans/create-pull-request@v5
         with:
@@ -63,22 +82,16 @@ jobs:
           labels: release
           committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
 
-      # pullRequestを承認
-      # 承認者がいない場合にpullRequestがマージできないため
-      - name: Approve Pull Request
-        if: steps.pullrequest.outputs.pull-request-operation == 'created'
-        env:
-          GITHUB_TOKEN: ${{ secrets.ACTION_ACCESS_TOKEN }}
-        run: gh pr review "${{ steps.pullrequest.outputs.pull-request-number }}" --approve
-
-      # pullRequestに自動マージを許可
-      - name: Enable Pull Request Automerge
-        if: steps.pullrequest.outputs.pull-request-operation == 'created'
-        uses: peter-evans/enable-pull-request-automerge@v3
-        with:
-          token: ${{ secrets.ACTION_ACCESS_TOKEN }}
-          pull-request-number: ${{ steps.pullrequest.outputs.pull-request-number }}
-          merge-method: merge
+      # リリースブランチにmainをマージ [リリースブランチがある場合]
+      - name: Merge Main to Release Branch
+        if: env.BRANCH_EXISTS == 'true'
+        # 先にget_versionの変更を取り消す
+        run: |
+          git checkout -- .
+          git clean -f
+          git checkout release/v${{ steps.get_version.outputs.next-version }}
+          git merge origin/main
+          git push
 
     outputs:
       current-version: ${{steps.get_version.outputs.current-version }}
@@ -96,7 +109,8 @@ jobs:
     # 各osで並列ビルド
     strategy:
       matrix:
-        os: [macos-latest, windows-latest]
+        os: [macos-latest, windows-latest ,ubuntu-latest]
+        new-ver: [true, false]
 
     runs-on: ${{ matrix.os }}
 
@@ -104,7 +118,9 @@ jobs:
       - uses: actions/checkout@v4
 
       # releaseブランチをチェックアウト
-      - run: |
+      - name: Checkout release branch
+        if: matrix.new-ver == true
+        run: |
           git fetch origin ${{ needs.create-commit.outputs.brench-name }}
           git checkout ${{ needs.create-commit.outputs.brench-name }}
 
@@ -117,27 +133,47 @@ jobs:
 
       # create-commitで行った更新をpullし、ビルドを実行
       - name: Pull and Build
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git pull
           yarn install
           yarn build
 
-      # Windowsのビルドデータを指定のパスに移動
-      - name: Move BuildData Win
+      # WindowsのビルドデータをArtifactとして一時保存
+      - name: Upload Artifact Win
         if: matrix.os == 'windows-latest'
-        run: mv "${{github.workspace}}/dist/electron/Packaged/ServerStarter2 ${{ needs.create-commit.outputs.next-version }}.msi" ${{ matrix.os }}
-
-      # Macのビルドデータを指定のパスに移動
-      - name: Move BuildData Mac
-        if: matrix.os == 'macos-latest'
-        run: mv "${{github.workspace}}/dist/electron/Packaged/ServerStarter2-${{ needs.create-commit.outputs.next-version }}.pkg" ${{ matrix.os }}
-
-      # ビルドデータをArtifactとして一時保存
-      - name: Upload Artifact
         uses: actions/upload-artifact@v3
         with:
-          name: ${{ matrix.os }}
-          path: ${{ matrix.os }}
+          name: ${{matrix.new-ver}}.msi
+          path: "${{github.workspace}}/dist/electron/Packaged/ServerStarter.build.msi"
+          retention-days: 1
+
+      # MacのビルドデータをArtifactとして一時保存
+      - name: Upload Artifact Mac
+        if: matrix.os == 'macos-latest'
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{matrix.new-ver}}.pkg
+          path: "${{github.workspace}}/dist/electron/Packaged/ServerStarter.build.pkg"
+          retention-days: 1
+
+      # Debianのビルドデータを指定のパスに移動
+      - name: Upload Artifact Debian
+        if: matrix.os == 'ubuntu-latest'
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{matrix.new-ver}}.deb
+          path: "${{github.workspace}}/dist/electron/Packaged/ServerStarter.build.deb"
+          retention-days: 1
+
+      # Redhatのビルドデータを指定のパスに移動
+      - name: Upload Artifact Redhat
+        if: matrix.os == 'ubuntu-latest'
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{matrix.new-ver}}.rpm
+          path: "${{github.workspace}}/dist/electron/Packaged/ServerStarter.build.rpm"
           retention-days: 1
 
   # リリースを作成
@@ -175,31 +211,46 @@ jobs:
     # 各osのビルドデータを並列処理
     strategy:
       matrix:
-        os: [macos-latest, windows-latest]
-        include:
-          - os: macos-latest
-            ext: pkg
-          - os: windows-latest
-            ext: msi
+        ext: [pkg, msi, deb, rpm]
 
     steps:
       # 一時保存したアーティファクトをダウンロード
       - name: Download Artifact
         uses: actions/download-artifact@v3
         with:
-          name: ${{ matrix.os }}
+          name: true.${{ matrix.ext }}
+          path: true/
 
       # リリースにビルドデータをアップロード
       - name: Upload a Release Asset
-        id: upload_release_asset
-        uses: actions/upload-release-asset@v1.0.2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        id: upload_release_asset_next
+        uses: shogo82148/actions-upload-release-asset@v1
         with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           upload_url: ${{ needs.create-release.outputs.upload_url }}
-          asset_path: ${{ matrix.os }}
+          asset_path: true/ServerStarter.build.${{ matrix.ext }}
           asset_name: ServerStarter-v${{ needs.create-commit.outputs.next-version }}.${{ matrix.ext }}
           asset_content_type: appliction/${{ matrix.ext }}
+          overwrite: true
+
+      # 一時保存したアーティファクトをダウンロード(現行バージョン)
+      - name: Download Artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: false.${{ matrix.ext }}
+          path: false/
+
+      # リリースにビルドデータをアップロード(現行バージョン)
+      - name: Upload a Release Asset
+        id: upload_release_asset_current
+        uses: shogo82148/actions-upload-release-asset@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          upload_url: ${{ needs.create-release.outputs.upload_url }}
+          asset_path: false/ServerStarter.build.${{ matrix.ext }}
+          asset_name: ServerStarter-v${{ needs.create-commit.outputs.current-version }}.${{ matrix.ext }}
+          asset_content_type: appliction/${{ matrix.ext }}
+          overwrite: true
 
   # Discordに通知
   notify:


### PR DESCRIPTION
# ビルドスクリプトを更新

## 変更点
- 自動承認機能を削除
- Linuxビルドに対応
- 現行バージョン値と新バージョン値の両者でビルド
- バージョン値を変えないリビルドに対応

## 申し送り
この変更に伴い、リリース時のオペレーションに変更があります。

### リリースの流れ ( v1.1.1 -> v1.1.2 )

1. リリースに含みたいすべての変更をmainに取り込む
2. GitHubActionでビルドスクリプトを実行
3. release/v1.1.2 ブランチと Draft Release と PR が自動作成される
4. Draft Release に計8つのビルド ( msi / pkg / deb / rpm ) x ( v1.1.1 / v1.1.2 ) が作成される。
5. SERVERSTARTER_MODE を debug にしてv1.1.1を使って動作確認 (v1.1.2 に更新されればOK)
6. 問題なければ PR を main にマージして完了

##### 問題があった場合

7. 問題を修正し変更をmainに取り込む
8. GitHubActionでビルドスクリプトを実行
9. release/v1.1.2 ブランチ と Draft Release が自動更新される
10. SERVERSTARTER_MODE を debug にしてv1.1.1を使って動作確認 (v1.1.2 に更新されればOK)
11. 6に戻る