### PR TITLE
ワールドフォルダの選択方法を変更

### DIFF
--- a/src/components/World/Others/WorldFolderView.vue
+++ b/src/components/World/Others/WorldFolderView.vue
@@ -3,35 +3,29 @@ import { ref, toRaw } from 'vue';
 import { useQuasar } from 'quasar';
 import { WorldContainer } from 'app/src-electron/schema/brands';
 import { deepcopy } from 'src/scripts/deepcopy';
-import { values } from 'src/scripts/obj';
 import { tError } from 'src/i18n/utils/tFunc';
 import { useConsoleStore } from 'src/stores/ConsoleStore';
-import { useMainStore, useWorldStore } from 'src/stores/MainStore';
+import { useMainStore } from 'src/stores/MainStore';
 import { useSystemStore } from 'src/stores/SystemStore';
 import { checkError } from 'src/components/Error/Error';
 import { AddFolderDialogReturns } from 'src/components/SystemSettings/Folder/iAddFolder';
-import AddContentsCard from 'src/components/util/AddContentsCard.vue';
+import SsSelectScope from 'src/components/util/base/ssSelectScope.vue';
+import SsTooltip from 'src/components/util/base/ssTooltip.vue';
 import AddFolderDialog from 'src/components/SystemSettings/Folder/AddFolderDialog.vue';
-import FolderCard from 'src/components/SystemSettings/Folder/FolderCard.vue';
 
 const $q = useQuasar();
 const sysStore = useSystemStore();
 const mainStore = useMainStore();
-const worldStore = useWorldStore();
 const consoleStore = useConsoleStore();
 
+const selecterOptions = sysStore.systemSettings.container.map((c) => {
+  return {
+    label: `${c.name} (${c.container})`,
+    name: c.name,
+    value: c.container,
+  };
+});
 const isWorldContainerLoading = ref(false);
-
-/**
- * ワールドフォルダの表示非表示を変更するときに、
- * 表示ワールドを残ったワールド一覧から選択する
- */
-function changeVisible(container: WorldContainer) {
-  if (mainStore.world.container === container) {
-    const world = values(worldStore.sortedWorldList);
-    mainStore.setWorld(world[world.length - 1]);
-  }
-}
 
 /**
  * ワールドコンテナをセットする際に、データの移動を待機する
@@ -77,33 +71,45 @@ function openFolderEditor() {
   <p class="text-caption" style="opacity: 0.6">
     {{ $t('others.worldFolder.description') }}
   </p>
-  <div class="column q-gutter-y-md">
-    <!-- v-modelの書き込みに対応するため、わざとインデックスによる呼び出しを利用 -->
-    <template
-      v-for="n in sysStore.systemSettings.container.length"
-      :key="sysStore.systemSettings.container[n - 1]"
+
+  <div class="row q-gutter-x-md">
+    <SsSelectScope
+      v-model="mainStore.noSubscribeWorld.container"
+      @update:model-value="(newVal: WorldContainer) => setWorldContainer(newVal)"
+      :options="selecterOptions"
+      option-label="label"
+      option-value="value"
+      :loading="isWorldContainerLoading"
+      :disable="
+        isWorldContainerLoading ||
+        consoleStore.status(mainStore.world.id) !== 'Stop'
+      "
+      class="col"
     >
-      <FolderCard
-        v-model="sysStore.systemSettings.container[n - 1]"
-        :loading="isWorldContainerLoading"
-        :disable="consoleStore.status(mainStore.world.id) !== 'Stop'"
-        :active="
-          mainStore.world.container ===
-          sysStore.systemSettings.container[n - 1].container
-        "
-        @click="
-          setWorldContainer(sysStore.systemSettings.container[n - 1].container)
-        "
-        @visible-click="
-          changeVisible(sysStore.systemSettings.container[n - 1].container)
-        "
+      <template v-slot:option="scope">
+        <q-item v-bind="scope.itemProps">
+          <q-item-section>
+            <q-item-label>{{ scope.opt.name }}</q-item-label>
+            <q-item-label caption>{{ scope.opt.value }}</q-item-label>
+          </q-item-section>
+        </q-item>
+      </template>
+    </SsSelectScope>
+
+    <q-btn outline icon="add" @click="openFolderEditor()">
+      <SsTooltip
+        :name="$t('others.worldFolder.addFolder')"
+        anchor="bottom middle"
+        self="center middle"
       />
-    </template>
-    <AddContentsCard
-      :label="$t('others.worldFolder.addFolder')"
-      min-height="3rem"
-      :card-style="{ 'min-width': '100%', 'border-radius': '5px' }"
-      @click="openFolderEditor"
-    />
+    </q-btn>
+
+    <q-btn outline icon="settings" @click="$router.push('/system/folder')">
+      <SsTooltip
+        :name="$t('others.worldFolder.openSettings')"
+        anchor="bottom middle"
+        self="center middle"
+      />
+    </q-btn>
   </div>
 </template>

--- a/src/components/util/base/ssSelectScope.vue
+++ b/src/components/util/base/ssSelectScope.vue
@@ -6,6 +6,7 @@ interface Prop {
   dense?: boolean;
   optionLabel?: string;
   optionValue?: string;
+  loading?: boolean;
 }
 
 const prop = defineProps<Prop>();
@@ -19,6 +20,7 @@ const model = defineModel();
     :options="options"
     :label="label"
     :dense="dense"
+    :loading="loading"
     :popup-content-style="{ fontSize: '0.9rem' }"
     :disable="disable"
     emit-value

--- a/src/i18n/en-US/Pages/World/others.ts
+++ b/src/i18n/en-US/Pages/World/others.ts
@@ -21,6 +21,7 @@ export const enOthers: MessageSchema['others'] = {
     title: 'World folder',
     description: 'Select your folder to save world data',
     addFolder: 'Add world folder',
+    openSettings: 'Open world folder\'s settings',
     updateFolder: 'Update world folder',
     add: 'Add a new World folder',
     addBtn: 'Add {0}{1}',

--- a/src/i18n/ja/Pages/World/others.ts
+++ b/src/i18n/ja/Pages/World/others.ts
@@ -19,6 +19,7 @@ export const jaOthers = {
     title: 'ワールドフォルダ',
     description: 'ワールドデータの保存フォルダを選択',
     addFolder: 'ワールドフォルダを追加',
+    openSettings: 'ワールドフォルダの設定を開く',
     updateFolder: 'ワールドフォルダを更新',
     add: '新規ワールドフォルダを追加',
     addBtn: '{1}を追加',

--- a/src/stores/MainStore.ts
+++ b/src/stores/MainStore.ts
@@ -38,6 +38,14 @@ export const useMainStore = defineStore('mainStore', {
       return returnWorld;
     },
     /**
+     * 通常のworldと異なり，内部データを変更してもSetWorldが呼び出されない
+     * 遅延評価でWorldデータを手動で更新する際に利用できる
+     */
+    noSubscribeWorld(state) {
+      const worldStore = useWorldStore();
+      return deepcopy(worldStore.worldList[state.selectedWorldID]);
+    },
+    /**
      * バージョンダウンの警告ダイアログのような，
      * 以前のデータとの比較が必要な処理への利用を想定する
      */


### PR DESCRIPTION
<!-- このPRはブランチを切った後，直ちに作成し，ブランチ内で変更する箇所を次章に列挙する -->

<!-- PRの作成時にはLabelsとAssignees（担当者）を割り当て，責任の所在を明確にする -->
<!-- PRの内容をすべて実装した際にReviewersを指定して，変更管理の承認を受ける -->

# ワールドフォルダの選択方法を変更
<!-- Pull Requestの概要を２行程度で説明する -->
<!-- このPRはブランチを切った後，直ちに作成し，ブランチ内で変更する箇所を次章に列挙する -->

ワールド編集画面の「その他の設定」タブにあるワールドフォルダの設定画面について，現状ではワールドフォルダが増えていくと画面の高さが長くなっていくUIとなっていることから，登録個数によって視認性の悪化が懸念される

そこで，ワールドフォルダのUIをバージョン等と同様のプルダウンメニューに変更することで，登録個数に依存せず画面高さが一定となるように変更

これに伴い，表示非表示の切り替えはワールド編集画面から削除し，代わりにシステム設定に飛ぶことができるボタンを配置


## 承認者への申し送り事項

- 変更箇所は一ヶ所のみで些少な変更ですが，内部ロジックの変更が入っているため，変更中の挙動（フォルダ変更中にサーバーが起動できない仕様）や表示中のワールドを切り替えた際の挙動などに不自然なものがないことを確認してください