### PR TITLE
追加コンテンツページをリストUI化

### DIFF
--- a/src/components/SystemSettings/Folder/AddFolderDialog.vue
+++ b/src/components/SystemSettings/Folder/AddFolderDialog.vue
@@ -76,7 +76,7 @@ function isErrorContainer(c: WorldContainerSetting) {
             inputName === '' ||
             pickPath === ''
           "
-          @click="
+          @click="() => 
             onDialogOK({
               name: inputName,
               container: pickPath,

--- a/src/components/World/Contents/CardView.vue
+++ b/src/components/World/Contents/CardView.vue
@@ -14,12 +14,13 @@ import { useMainStore } from 'src/stores/MainStore';
 import { useSystemStore } from 'src/stores/SystemStore';
 import { checkError } from 'src/components/Error/Error';
 import AddContentsCard from 'src/components/util/AddContentsCard.vue';
-import ItemCardView from './itemCardView.vue';
+import ItemCard from './CardView/itemCard.vue';
+import { ContentsType } from './contentsPage';
 
 type T = DatapackData | PluginData | ModData;
 
 interface Prop {
-  contentType: 'datapack' | 'plugin' | 'mod';
+  contentType: ContentsType;
 }
 const prop = defineProps<Prop>();
 
@@ -177,7 +178,7 @@ async function openCacheFolder() {
           :key="item.name"
           class="col-"
         >
-          <ItemCardView :content-type="contentType" is-delete :content="item" />
+          <ItemCard :content-type="contentType" is-delete :content="item" />
         </div>
       </template>
       <div v-else class="full-width">
@@ -251,7 +252,7 @@ async function openCacheFolder() {
         )"
         :key="item.name"
       >
-        <ItemCardView :content-type="contentType" :content="item" />
+        <ItemCard :content-type="contentType" :content="item" />
       </div>
     </div>
   </div>

--- a/src/components/World/Contents/CardView/itemCard.vue
+++ b/src/components/World/Contents/CardView/itemCard.vue
@@ -1,75 +1,23 @@
 <script setup lang="ts">
-import { computed } from 'vue';
-import { useQuasar } from 'quasar';
 import { AllFileData } from 'app/src-electron/schema/filedata';
-import { $T } from 'src/i18n/utils/tFunc';
-import { useMainStore } from 'src/stores/MainStore';
-import { useContentsStore } from 'src/stores/WorldTabs/ContentsStore';
-import { dangerDialogProp } from 'src/components/util/danger/iDangerDialog';
 import SsTooltip from 'src/components/util/base/ssTooltip.vue';
-import DangerDialog from 'src/components/util/danger/DangerDialog.vue';
 import BaseActionsCard from '../../utils/BaseActionsCard.vue';
-import { ContentsData } from '../contentsPage';
+import {
+  addContent,
+  ContentsData,
+  ContentsType,
+  deleteContent,
+  showingContentDescription,
+  showingContentName,
+} from '../contentsPage';
 
 interface Prop {
-  contentType: 'datapack' | 'plugin' | 'mod';
+  contentType: ContentsType;
   content: AllFileData<ContentsData>;
   isDelete?: boolean;
   color?: string;
 }
-const prop = defineProps<Prop>();
-
-const $q = useQuasar();
-const mainStore = useMainStore();
-const contentsStore = useContentsStore();
-
-function addContent() {
-  (
-    mainStore.world.additional[
-      `${prop.contentType}s`
-    ] as AllFileData<ContentsData>[]
-  ).push(prop.content);
-}
-
-function deleteContent() {
-  function __delete() {
-    mainStore.world.additional[`${prop.contentType}s`].splice(
-      mainStore.world.additional[`${prop.contentType}s`]
-        .map((c) => c.name)
-        .indexOf(prop.content.name),
-      1
-    );
-  }
-
-  // 起動前に登録された追加コンテンツに対して警告を出さない
-  if (contentsStore.isNewContents(prop.content)) {
-    __delete();
-  } else {
-    $q.dialog({
-      component: DangerDialog,
-      componentProps: {
-        dialogTitle: $T('additionalContents.deleteDialog.title', {
-          type: prop.contentType,
-        }),
-        dialogDesc: $T('additionalContents.deleteDialog.desc', {
-          type: prop.contentType,
-        }),
-        okBtnTxt: $T('additionalContents.deleteDialog.okbtn'),
-      } as dangerDialogProp,
-    }).onOk(() => {
-      __delete();
-    });
-  }
-}
-
-const transformedName = computed(() =>
-  prop.content.name.replace(/§./g, '').trim()
-);
-const transformedDescription = computed(() =>
-  'description' in prop.content
-    ? prop.content.description.replace(/§./g, '').trim()
-    : ''
-);
+defineProps<Prop>();
 </script>
 
 <template>
@@ -83,9 +31,9 @@ const transformedDescription = computed(() =>
       <q-item class="q-pr-sm">
         <q-item-section>
           <q-item-label class="contentsName text-omit">
-            {{ transformedName }}
+            {{ showingContentName(content) }}
             <SsTooltip
-              :name="transformedName"
+              :name="showingContentName(content)"
               anchor="bottom start"
               self="center start"
             />
@@ -95,9 +43,9 @@ const transformedDescription = computed(() =>
             class="text-omit"
             style="opacity: 0.7"
           >
-            {{ transformedDescription }}
+            {{ showingContentDescription(content) }}
             <SsTooltip
-              :name="transformedDescription"
+              :name="showingContentDescription(content)"
               anchor="bottom start"
               self="center start"
             />
@@ -112,7 +60,7 @@ const transformedDescription = computed(() =>
             color="negative"
             icon="close"
             size="1rem"
-            @click="deleteContent"
+            @click="deleteContent(contentType, content)"
           >
             <div
               class="text-negative text-center full-width"
@@ -130,7 +78,7 @@ const transformedDescription = computed(() =>
             color="primary"
             icon="add"
             size="1rem"
-            @click="addContent"
+            @click="addContent(contentType, content)"
           >
             <div
               class="text-primary text-center full-width"

--- a/src/components/World/Contents/CardView/itemCard.vue
+++ b/src/components/World/Contents/CardView/itemCard.vue
@@ -1,25 +1,19 @@
 <script setup lang="ts">
 import { computed } from 'vue';
 import { useQuasar } from 'quasar';
-import {
-  AllFileData,
-  DatapackData,
-  ModData,
-  PluginData,
-} from 'app/src-electron/schema/filedata';
+import { AllFileData } from 'app/src-electron/schema/filedata';
 import { $T } from 'src/i18n/utils/tFunc';
 import { useMainStore } from 'src/stores/MainStore';
 import { useContentsStore } from 'src/stores/WorldTabs/ContentsStore';
 import { dangerDialogProp } from 'src/components/util/danger/iDangerDialog';
 import SsTooltip from 'src/components/util/base/ssTooltip.vue';
 import DangerDialog from 'src/components/util/danger/DangerDialog.vue';
-import BaseActionsCard from '../utils/BaseActionsCard.vue';
-
-type T = DatapackData | ModData | PluginData;
+import BaseActionsCard from '../../utils/BaseActionsCard.vue';
+import { ContentsData } from '../contentsPage';
 
 interface Prop {
   contentType: 'datapack' | 'plugin' | 'mod';
-  content: AllFileData<T>;
+  content: AllFileData<ContentsData>;
   isDelete?: boolean;
   color?: string;
 }
@@ -30,9 +24,11 @@ const mainStore = useMainStore();
 const contentsStore = useContentsStore();
 
 function addContent() {
-  (mainStore.world.additional[`${prop.contentType}s`] as AllFileData<T>[]).push(
-    prop.content
-  );
+  (
+    mainStore.world.additional[
+      `${prop.contentType}s`
+    ] as AllFileData<ContentsData>[]
+  ).push(prop.content);
 }
 
 function deleteContent() {

--- a/src/components/World/Contents/ListView.vue
+++ b/src/components/World/Contents/ListView.vue
@@ -2,7 +2,11 @@
 import { useContentsStore } from 'src/stores/WorldTabs/ContentsStore';
 import SsIconBtn from 'src/components/util/base/ssIconBtn.vue';
 import SsInput from 'src/components/util/base/ssInput.vue';
-import { ContentsType, openSavedFolder } from './contentsPage';
+import {
+  ContentsType,
+  importNewContent,
+  openSavedFolder,
+} from './contentsPage';
 
 interface Prop {
   contentType: ContentsType;
@@ -33,6 +37,7 @@ const contentsStore = useContentsStore();
         size=".8rem"
         icon="library_add"
         tooltip="追加コンテンツのファイルを新規追加"
+        @click="() => importNewContent(contentType, true)"
       />
       <SsIconBtn
         flat

--- a/src/components/World/Contents/ListView.vue
+++ b/src/components/World/Contents/ListView.vue
@@ -1,0 +1,48 @@
+<script setup lang="ts">
+import { useContentsStore } from 'src/stores/WorldTabs/ContentsStore';
+import SsIconBtn from 'src/components/util/base/ssIconBtn.vue';
+import SsInput from 'src/components/util/base/ssInput.vue';
+import { ContentsType, openSavedFolder } from './contentsPage';
+
+interface Prop {
+  contentType: ContentsType;
+}
+defineProps<Prop>();
+const contentsStore = useContentsStore();
+</script>
+
+<template>
+  <div class="q-px-md">
+    <h1 class="q-py-xs">
+      {{
+        $t('additionalContents.management', {
+          type: $t(`additionalContents.${contentType}`),
+        })
+      }}
+    </h1>
+
+    <div class="row items-center q-gutter-md">
+      <SsInput
+        v-model="contentsStore.searchText"
+        dense
+        placeholder="追加や絞り込みしたいコンテンツ名を入力"
+        class="col"
+      />
+      <SsIconBtn
+        flat
+        size=".8rem"
+        icon="library_add"
+        tooltip="追加コンテンツのファイルを新規追加"
+      />
+      <SsIconBtn
+        flat
+        size=".8rem"
+        icon="folder_open"
+        tooltip="保存先フォルダを開く"
+        @click="() => openSavedFolder(contentType)"
+      />
+    </div>
+  </div>
+</template>
+
+<style scoped lang="scss"></style>

--- a/src/components/World/Contents/ListView.vue
+++ b/src/components/World/Contents/ListView.vue
@@ -112,6 +112,7 @@ function addContentClicked(content: AllFileData<ContentsData>) {
         @click="() => importNewContent(contentType, true)"
       />
       <SsIconBtn
+        v-if="contentType !== 'datapack'"
         flat
         size=".8rem"
         icon="folder_open"

--- a/src/components/World/Contents/ListView/ListItem.vue
+++ b/src/components/World/Contents/ListView/ListItem.vue
@@ -1,14 +1,46 @@
 <script setup lang="ts">
+import { ref } from 'vue';
 import { AllFileData } from 'app/src-electron/schema/filedata';
-import { ContentsData } from '../contentsPage';
+import SsIconBtn from 'src/components/util/base/ssIconBtn.vue';
+import {
+  ContentsData,
+  deleteContent,
+  showingContentDescription,
+  showingContentName,
+} from '../contentsPage';
 
 interface Prop {
   contentType: 'datapack' | 'plugin' | 'mod';
   content: AllFileData<ContentsData>;
 }
 defineProps<Prop>();
+
+const hover = ref(false);
 </script>
 
 <template>
-  <q-item> </q-item>
+  <q-item @mouseenter="hover = true" @mouseleave="hover = false">
+    <q-item-section>
+      <q-item-label style="font-size: 1rem">
+        {{ showingContentName(content) }}
+      </q-item-label>
+      <q-item-label v-if="'description' in content" style="opacity: 0.7">
+        {{ showingContentDescription(content) }}
+      </q-item-label>
+    </q-item-section>
+
+    <q-item-section side v-show="hover">
+      <div class="row q-gutter-x-sm">
+        <SsIconBtn flat icon="info" tooltip="詳細情報" @click="() => {}" />
+        <q-separator vertical />
+        <SsIconBtn
+          flat
+          icon="close"
+          tooltip="削除"
+          color="negative"
+          @click="() => deleteContent(contentType, content)"
+        />
+      </div>
+    </q-item-section>
+  </q-item>
 </template>

--- a/src/components/World/Contents/ListView/ListItem.vue
+++ b/src/components/World/Contents/ListView/ListItem.vue
@@ -1,0 +1,14 @@
+<script setup lang="ts">
+import { AllFileData } from 'app/src-electron/schema/filedata';
+import { ContentsData } from '../contentsPage';
+
+interface Prop {
+  contentType: 'datapack' | 'plugin' | 'mod';
+  content: AllFileData<ContentsData>;
+}
+defineProps<Prop>();
+</script>
+
+<template>
+  <q-item> </q-item>
+</template>

--- a/src/components/World/Contents/contentsPage.ts
+++ b/src/components/World/Contents/contentsPage.ts
@@ -1,6 +1,9 @@
 import {
+  AllFileData,
+  CacheFileData,
   DatapackData,
   ModData,
+  NewFileData,
   PluginData,
 } from 'app/src-electron/schema/filedata';
 import { Version } from 'app/src-electron/schema/version';
@@ -30,6 +33,71 @@ export const isContentsExists: contentExists = {
 };
 
 /**
+ * コンテンツを新規導入
+ */
+export async function importNewContent(cType: ContentsType, isFile = false) {
+  // エラー回避のため、意図的にswitchで分岐して表現を分かりやすくしている
+  switch (cType) {
+    case 'datapack':
+      checkError(
+        await window.API.invokePickDialog({ type: 'datapack', isFile: isFile }),
+        (c) => addContent2World(cType, c),
+        (e) => tError(e, { ignoreErrors: ['data.path.dialogCanceled'] })
+      );
+      break;
+    case 'plugin':
+      checkError(
+        await window.API.invokePickDialog({ type: 'plugin' }),
+        (c) => addContent2World(cType, c),
+        (e) => tError(e, { ignoreErrors: ['data.path.dialogCanceled'] })
+      );
+      break;
+    case 'mod':
+      checkError(
+        await window.API.invokePickDialog({ type: 'mod' }),
+        (c) => addContent2World(cType, c),
+        (e) => tError(e, { ignoreErrors: ['data.path.dialogCanceled'] })
+      );
+      break;
+  }
+}
+
+/**
+ * コンテンツを各種データベースに登録
+ */
+function addContent2World(
+  cType: ContentsType,
+  content: NewFileData<ContentsData>
+) {
+  const sysStore = useSystemStore();
+  const mainStore = useMainStore();
+  function NewFile2CacheFile(): CacheFileData<ContentsData> {
+    if (content.kind === 'datapack') {
+      return {
+        kind: 'datapack',
+        description: content.description,
+        type: 'system',
+        name: content.name,
+        ext: content.ext,
+        isFile: content.isFile,
+      };
+    } else {
+      return {
+        kind: content.kind,
+        type: 'system',
+        name: content.name,
+        ext: content.ext,
+        isFile: content.isFile,
+      };
+    }
+  }
+  (mainStore.world.additional[`${cType}s`] as AllFileData<ContentsData>[]).push(content);
+  (sysStore.cacheContents[`${cType}s`] as CacheFileData<ContentsData>[]).push(
+    NewFile2CacheFile()
+  );
+}
+
+/**
  * 保存済みデータのフォルダを開く
  *
  * Stopの時にはキャッシュ側のフォルダを開き，動作中はワールドデータ側のフォルダを開く
@@ -43,7 +111,10 @@ export async function openSavedFolder(cType: ContentsType) {
         const sysStore = useSystemStore();
         return sysStore.staticResouces.paths.cache[cType];
       default:
-        return await window.API.invokeGetWorldPaths(mainStore.world.id, `${cType}s`);
+        return await window.API.invokeGetWorldPaths(
+          mainStore.world.id,
+          `${cType}s`
+        );
     }
   };
   const path = await getPath();

--- a/src/components/World/Contents/contentsPage.ts
+++ b/src/components/World/Contents/contentsPage.ts
@@ -1,4 +1,17 @@
+import {
+  DatapackData,
+  ModData,
+  PluginData,
+} from 'app/src-electron/schema/filedata';
 import { Version } from 'app/src-electron/schema/version';
+import { tError } from 'src/i18n/utils/tFunc';
+import { useConsoleStore } from 'src/stores/ConsoleStore';
+import { useMainStore } from 'src/stores/MainStore';
+import { useSystemStore } from 'src/stores/SystemStore';
+import { checkError } from 'src/components/Error/Error';
+
+export type ContentsData = DatapackData | ModData | PluginData;
+export type ContentsType = 'datapack' | 'plugin' | 'mod';
 
 type contentExists = {
   [ver in Version['type']]: {
@@ -15,3 +28,32 @@ export const isContentsExists: contentExists = {
   mohistmc: { datapack: true, plugin: true, mod: true },
   fabric: { datapack: true, plugin: false, mod: true },
 };
+
+/**
+ * 保存済みデータのフォルダを開く
+ *
+ * Stopの時にはキャッシュ側のフォルダを開き，動作中はワールドデータ側のフォルダを開く
+ */
+export async function openSavedFolder(cType: ContentsType) {
+  const getPath = async () => {
+    const mainStore = useMainStore();
+    const consoleStore = useConsoleStore();
+    switch (consoleStore.status(mainStore.world.id)) {
+      case 'Stop':
+        const sysStore = useSystemStore();
+        return sysStore.staticResouces.paths.cache[cType];
+      default:
+        return await window.API.invokeGetWorldPaths(mainStore.world.id, `${cType}s`);
+    }
+  };
+  const path = await getPath();
+
+  checkError(
+    path,
+    async (p) => {
+      const res = await window.API.sendOpenFolder(p, true);
+      checkError(res, undefined, (e) => tError(e));
+    },
+    (e) => tError(e)
+  );
+}

--- a/src/components/World/Contents/contentsPage.ts
+++ b/src/components/World/Contents/contentsPage.ts
@@ -199,21 +199,11 @@ export function deleteContent(
  * Stopの時にはキャッシュ側のフォルダを開き，動作中はワールドデータ側のフォルダを開く
  */
 export async function openSavedFolder(cType: ContentsType) {
-  const getPath = async () => {
-    const mainStore = useMainStore();
-    const consoleStore = useConsoleStore();
-    switch (consoleStore.status(mainStore.world.id)) {
-      case 'Stop':
-        const sysStore = useSystemStore();
-        return sysStore.staticResouces.paths.cache[cType];
-      default:
-        return await window.API.invokeGetWorldPaths(
-          mainStore.world.id,
-          `${cType}s`
-        );
-    }
-  };
-  const path = await getPath();
+  const mainStore = useMainStore();
+  const path = await window.API.invokeGetWorldPaths(
+    mainStore.world.id,
+    `${cType}s`
+  );
 
   checkError(
     path,

--- a/src/components/World/Contents/contentsPage.ts
+++ b/src/components/World/Contents/contentsPage.ts
@@ -57,16 +57,18 @@ export function getAllContents(cType: ContentsType): OptContents[] {
   const returnArray = sysStore.cacheContents[`${cType}s`].map((c) =>
     __converter(c)
   );
-  mainStore
-    .getFromAllWorld((w) =>
-      w.additional[`${cType}s`].map((c) => __converter(c, w.name))
-    )
-    .flat()
-    .forEach((c) => {
-        returnArray.push(c);
-      // if (!returnArray.some((_c) => _c.name === c.name)) {
-      // }
-    });
+  // TODO: 各ワールドに入っている追加コンテンツはShareWorldのみ，returnArrayに統合する
+  // mainStore
+  //   .getFromAllWorld((w) =>
+  //     w.additional[`${cType}s`].map((c) => __converter(c, w.name))
+  //   )
+  //   .flat()
+  //   .forEach((c) => {
+  //     // 統合時の条件には，名前ではなく，Hashが同じコンテンツがすでに存在するか否かで検証する
+  //     if (!returnArray.some((_c) => _c.name === c.name)) {
+  //       returnArray.push(c);
+  //     }
+  //   });
   return returnArray;
 }
 

--- a/src/components/World/HOME/Others/Ngrok/NgrokSettingDialog.vue
+++ b/src/components/World/HOME/Others/Ngrok/NgrokSettingDialog.vue
@@ -75,7 +75,7 @@ if (!isRegisteredNgrok) {
           v-show="step !== 1 && !isRegisteredNgrok"
           flat
           free-width
-          @click="stepper?.previous()"
+          @click="() => stepper?.previous()"
           :label="$t('general.back')"
           class="q-mr-sm"
         />
@@ -89,7 +89,11 @@ if (!isRegisteredNgrok) {
           "
           color="primary"
           :disable="step === 3 && step3Model.token === ''"
-          @click="step === 3 ? onDialogOK(step3Model) : stepper?.next()"
+          @click="
+            () => {
+              return step === 3 ? onDialogOK(step3Model) : stepper?.next();
+            }
+          "
         />
       </template>
     </BaseDialogCard>

--- a/src/components/World/HOME/RunningBtn.vue
+++ b/src/components/World/HOME/RunningBtn.vue
@@ -73,6 +73,7 @@ function stopButtonState() {
     v-else-if="consoleStore.isClickedReboot(mainStore.selectedWorldID)"
     free-width
     disable
+    @click="() => {}"
     :style="{ height: `${3 ** (textFontSize + 0.1)}rem` }"
     class="row items-center"
   >

--- a/src/components/util/base/ssBtn.vue
+++ b/src/components/util/base/ssBtn.vue
@@ -1,32 +1,21 @@
 <script setup lang="ts">
+import { QBtnProps } from 'quasar';
+
 interface Prop {
-  icon?: string;
-  label?: string;
-  dense?: boolean;
-  color?: string;
-  width?: string;
   freeWidth?: boolean;
-  disable?: boolean;
-  loading?: boolean;
-  isCapital?: boolean;
-  to?: string;
-  onClick?: () => void;
+  width?: string;
+  isCapital?: boolean
+  onClick: () => void;
 }
-defineProps<Prop>();
+const prop = defineProps<Prop & QBtnProps>();
 </script>
 
 <template>
   <q-btn
+    v-bind="prop"
     outline
-    :dense="dense"
-    :icon="icon"
-    :label="label"
-    :color="color"
     :disable="loading || disable"
-    :loading="loading"
     :no-caps="!isCapital"
-    :to="to"
-    @click="onClick"
     :style="{ width: freeWidth ? '' : width ?? '13rem' }"
   >
     <slot />

--- a/src/components/util/base/ssIconBtn.vue
+++ b/src/components/util/base/ssIconBtn.vue
@@ -1,0 +1,23 @@
+<script setup lang="ts">
+import { QBtnProps } from 'quasar';
+import SsBtn from './ssBtn.vue';
+import SsTooltip from './ssTooltip.vue';
+
+interface Prop {
+  icon?: string;
+  iconSrc?: string;
+  tooltip: string;
+  onClick: () => void;
+}
+const prop = defineProps<Prop & QBtnProps>();
+</script>
+
+<template>
+  <SsBtn v-bind="prop" free-width dense @click="onClick">
+    <q-avatar v-if="iconSrc" square class="q-ma-xs">
+      <q-icon :name="iconSrc" />
+    </q-avatar>
+
+    <SsTooltip :name="tooltip" anchor="bottom middle" self="center middle" />
+  </SsBtn>
+</template>

--- a/src/components/util/base/ssTooltip.vue
+++ b/src/components/util/base/ssTooltip.vue
@@ -40,7 +40,6 @@ interface Prop {
   anchor?: Anchor;
   self?: Self;
   fontSize?: string;
-  maxWidth?: string;
 }
 defineProps<Prop>();
 </script>
@@ -50,7 +49,6 @@ defineProps<Prop>();
     <div
       class="q-pa-xs"
       :style="{
-        width: maxWidth,
         color: $q.dark.isActive ? 'white' : 'black',
         'background-color': $q.dark.isActive
           ? getCssVar('dark')?.toString()
@@ -58,7 +56,12 @@ defineProps<Prop>();
         border: `1.5px solid grey`,
         'font-size': fontSize ?? '.7rem',
       }"
-      style="word-break: break-word; border-radius: 5px; white-space: pre-line"
+      style="
+        word-break: break-word;
+        border-radius: 5px;
+        white-space: pre-line;
+        width: max-content;
+      "
     >
       {{ name }}
     </div>

--- a/src/components/util/baseDialog/baseDialogCard.vue
+++ b/src/components/util/baseDialog/baseDialogCard.vue
@@ -21,7 +21,7 @@ defineProps<baseDialogProp>();
     <q-card-actions align="right">
       <slot name="additionalBtns" />
       <ss-btn
-        v-if="okBtnTxt !== void 0 || onOkClick !== void 0"
+        v-if="okBtnTxt !== void 0 && onOkClick !== void 0"
         :disable="disable"
         :loading="loading"
         :label="okBtnTxt"

--- a/src/pages/WorldTabs/ContentsPage.vue
+++ b/src/pages/WorldTabs/ContentsPage.vue
@@ -1,12 +1,20 @@
 <script setup lang="ts">
 import { useContentsStore } from 'src/stores/WorldTabs/ContentsStore';
-import ContentsView from 'src/components/World/Contents/ContentsView.vue';
+import CardView from 'src/components/World/Contents/CardView.vue';
+import ListView from 'src/components/World/Contents/ListView.vue';
 
 const contentsStore = useContentsStore();
 </script>
 
 <template>
   <q-scroll-area class="full-height" style="flex: 1 1 0">
-    <ContentsView :content-type="contentsStore.getShowingContentPage()" />
+    <CardView
+      v-if="false"
+      :content-type="contentsStore.getShowingContentPage()"
+    />
+    <ListView
+      v-if="true"
+      :content-type="contentsStore.getShowingContentPage()"
+    />
   </q-scroll-area>
 </template>

--- a/src/pages/WorldTabs/PlayerPage.vue
+++ b/src/pages/WorldTabs/PlayerPage.vue
@@ -189,7 +189,7 @@ function openGroupEditor(group?: PlayerGroup) {
       <SsBtn
         :label="$t('player.resetPlayerSettings')"
         color="primary"
-        @click="mainStore.world.players = []"
+        @click="() => mainStore.world.players = []"
         class="full-width"
       />
     </div>

--- a/src/pages/WorldTabs/PropertyPage.vue
+++ b/src/pages/WorldTabs/PropertyPage.vue
@@ -92,7 +92,7 @@ function scrollTop() {
         <SsBtn
           :label="$t('property.reset')"
           color="primary"
-          @click="mainStore.world.properties = initProperty"
+          @click="() => mainStore.world.properties = initProperty"
           class="full-width"
         />
       </div>

--- a/src/stores/MainStore.ts
+++ b/src/stores/MainStore.ts
@@ -192,6 +192,13 @@ export const useMainStore = defineStore('mainStore', {
       });
     },
     /**
+     * すべてのワールドに対してprocessで指定した処理を行った結果を返す
+     */
+    getFromAllWorld<T>(process: (world: WorldEdited) => T) {
+      const worldStore = useWorldStore();
+      return values(worldStore.worldList).map(process);
+    },
+    /**
      * Ngrokより割り当てられたIPアドレスを削除する（サーバー終了時を想定）
      */
     removeWorldIP(worldID: WorldID) {

--- a/src/stores/WorldTabs/ContentsStore.ts
+++ b/src/stores/WorldTabs/ContentsStore.ts
@@ -14,6 +14,7 @@ export const useContentsStore = defineStore('contentsStore', {
   state: () => {
     return {
       selectedTab: 'datapack' as 'datapack' | 'plugin' | 'mod',
+      searchText: ''
     };
   },
   actions: {


### PR DESCRIPTION
<!-- このPRはブランチを切った後，直ちに作成し，ブランチ内で変更する箇所を次章に列挙する -->

<!-- PRの作成時にはLabelsとAssignees（担当者）を割り当て，責任の所在を明確にする -->
<!-- PRの内容をすべて実装した際にReviewersを指定して，変更管理の承認を受ける -->

# 追加コンテンツページをリストUI化

<!-- Pull Requestの概要を２行程度で説明する -->
<!-- このPRはブランチを切った後，直ちに作成し，ブランチ内で変更する箇所を次章に列挙する -->

追加コンテンツタブの表示画面が，現行のUIではプレイヤーと同様にカード形式を採用しているものの，一覧性が悪く，百数十件規模で追加コンテンツが導入されている際や長い名前の追加コンテンツの導入時に，視認性が悪い

今回の改善ではUIをリスト形式に変更し，これに伴う追加機能の実装を行う

（本PRはバックエンド実装前にCloseするため，下記の変更箇所の一部は未完の状態でMargeする．完了後に対応するPRを下記に記載していくことで，追加コンテンツに関連する実装の進捗を表現する）


## 変更箇所
<!-- 変更内容を列挙し，小項目は必要に応じて利用する -->
<!-- Issuesから引用する際には「#00 を修正」のように記載し，Developmentに当該Issueを忘れずに登録する -->
- [ ] 表示形式をリスト化
  - プレイヤーとは異なり，カード形式の表示方法は廃止する
- [ ] コンテンツ追加方法の変更
  - [ ] 名称検索による追加コンテンツのサジェスト（「詳細情報」の`copieable`が`False`の時には，サジェスト候補に当該コンテンツを追加しない）
  - [ ] 単一ファイルからの導入（FilePicker | drug & drop）
  - [ ] 指定したワールドからの一括導入（すでにHashが同じコンテンツが導入済みの際には，当該コンテンツを追加対象として選択できないように`disable`（≠非表示）にする）
  - [ ] 追加時，追加先に同名のコンテンツが存在する場合は，`<コンテンツ名>_from_<元のワールド名>`に名前を変更して導入する
- [ ] 各追加コンテンツに「詳細情報」を新設
  - [ ] 「詳細情報」を入力するためのダイアログを作成（詳細情報の適用範囲（ローカルは全体，ShareWorldは当該ワールドのみ）について言及する）
  - [ ] ダイアログの入力内容や初期表示内容が最終確定時のオブジェクトに対して成立させる
  - [ ] 「詳細情報」のうち，自由記述欄（＝メモ）にURLが添付された際にはURLをクリックできるようにする
  - [ ] 任意の導入履歴のあるコンテンツを追加する際には，原則導入元で設定した「詳細情報」を導入先にも適用するが，ShareWorldからすでに同じHashがローカルに存在するコンテンツをローカルに導入する際には，ローカルの詳細情報を使用する旨をダイアログでユーザーに通知する
- [ ] 「保存先を開く」機能の仕様変更
  - [ ] ローカルワールドについては，`invokeGetWorldPaths()`で取得されるパスを開く（ただし，データパックは非表示）
  - [ ] ShareWorldについては，`onStartServer()`で返却される`notifications`より指定されたパスを開く（現状ではこの情報を保持できないため，NgrokのURL等と同様に保存場所を作成する）
- [ ] APIやオブジェクトの仕様変更
  - [ ] `world..additional[contentType]`が廃止となり，`world.contentIDs[contentType]`に変更されるため，IDからコンテンツの実態データを引き出す処理フローに変更し，更新時も新設のAPI（`UpdateContent(worldID, contentID, newContent)`？）とフロント側のデータストアを呼び出すことで更新する処理フローに変更
  - [ ] 任意のファイルから新規追加する際にも新設のAPI（`RegistContent(worldID, filepath) -> contentID`？）を用いてIDを発行し，発行したIDを用いて，導入履歴のあるコンテンツと同様の処理フローに乗せる
- [ ] 各画面の翻訳

<!--
## 承認者への申し送り事項

- 申し送り事項を記載しておく必要がある場合に追記する

-->