### PR TITLE
ワールド関連のファイル操作を実装

### DIFF
--- a/src-electron/v2/schema/serverproperty.ts
+++ b/src-electron/v2/schema/serverproperty.ts
@@ -1,0 +1,50 @@
+import { z } from 'zod';
+
+export const StringServerPropertyAnnotation = z.object({
+  type: z.enum(['string']),
+  default: z.string(),
+  enum: z.string().array().optional(),
+});
+export type StringServerPropertyAnnotation = z.infer<
+  typeof StringServerPropertyAnnotation
+>;
+
+export const BooleanServerPropertyAnnotation = z.object({
+  type: z.enum(['boolean']),
+  default: z.boolean(),
+});
+export type BooleanServerPropertyAnnotation = z.infer<
+  typeof BooleanServerPropertyAnnotation
+>;
+
+export const NumberServerPropertyAnnotation = z.object({
+  type: z.enum(['number']),
+  default: z.number(),
+
+  /** value % step == 0 */
+  step: z.number().optional(),
+
+  /** min <= value <= max */
+  min: z.number().optional(),
+  max: z.number().optional(),
+});
+export type NumberServerPropertyAnnotation = z.infer<
+  typeof NumberServerPropertyAnnotation
+>;
+
+export const ServerPropertyAnnotation = StringServerPropertyAnnotation.or(
+  BooleanServerPropertyAnnotation.or(NumberServerPropertyAnnotation)
+);
+export type ServerPropertyAnnotation = z.infer<typeof ServerPropertyAnnotation>;
+
+/** サーバープロパティのアノテーション */
+export const ServerPropertiesAnnotation = z.record(ServerPropertyAnnotation);
+export type ServerPropertiesAnnotation = z.infer<
+  typeof ServerPropertiesAnnotation
+>;
+
+/** サーバープロパティのデータ */
+export const ServerProperties = z.record(
+  z.string().or(z.number().or(z.boolean()))
+);
+export type ServerProperties = z.infer<typeof ServerProperties>;

--- a/src-electron/v2/schema/world.ts
+++ b/src-electron/v2/schema/world.ts
@@ -5,6 +5,7 @@ import { Mod } from './mod';
 import { OpLevel, PlayerName, PlayerUUID } from './player';
 import { Plugin } from './plugin';
 import { RuntimeSettings } from './runtime';
+import { ServerProperties } from './serverproperty';
 import { UnixMillisec } from './time';
 import { McTimestamp } from './timestamp';
 import { Version } from './version';
@@ -58,12 +59,21 @@ export const OpPlayer = z.object({
 });
 export type OpPlayer = z.infer<typeof OpPlayer>;
 
+export const WhitelistPlayer = z.object({
+  uuid: PlayerUUID,
+  name: PlayerName,
+});
+export type WhitelistPlayer = z.infer<typeof WhitelistPlayer>;
+
 export const World = z.object({
   /** 起動中フラグ */
   using: z.boolean(),
 
   /** バージョン情報 */
   version: Version,
+
+  /** `server.properties`の情報 */
+  properties: ServerProperties,
 
   /** データパック */
   datapack: z.array(DatapackMeta),

--- a/src-electron/v2/source/world/container.ts
+++ b/src-electron/v2/source/world/container.ts
@@ -45,7 +45,7 @@ export interface WorldContainerHandler {
    *
    * 展開に失敗した場合は元の状態に戻す
    *
-   * properties / eula / op / whitelist
+   * properties / op / whitelist / bannedIps / bannedPlayers
    *
    * mod / plugin / datapack の展開は行わない
    */

--- a/src-electron/v2/source/world/local.ts
+++ b/src-electron/v2/source/world/local.ts
@@ -1,10 +1,21 @@
-import { World, WorldLocation, WorldName } from '../../schema/world';
+import { z } from 'zod';
+import {
+  BannedIp,
+  BannedPlayer,
+  OpPlayer,
+  WhitelistPlayer,
+  World,
+  WorldLocation,
+  WorldName,
+} from '../../schema/world';
 import { err, ok, Result } from '../../util/base';
 import { Json } from '../../util/binary/json';
 import { Path } from '../../util/binary/path';
 import { InfinitMap } from '../../util/helper/infinitMap';
 import { AsyncCache } from '../../util/promise/cache';
+import { JsonSourceHandler } from '../../util/wrapper/jsonFile';
 import { WorldContainerHandler } from './container';
+import { stringify } from './properties';
 
 const SETTING_FILE_NAME = 'server_settings.json';
 
@@ -13,10 +24,34 @@ const SETTING_FILE_NAME = 'server_settings.json';
  */
 export class LocalWorldSource implements WorldContainerHandler {
   private dirpath: Path;
+  private jsonHandlers;
+  private outputPaths;
   private worldMataMap: InfinitMap<WorldName, AsyncCache<World>>;
 
   constructor(dirpath: Path) {
     this.dirpath = dirpath;
+    this.outputPaths = {
+      properties: dirpath.child('server.properties'),
+      bannedIps: dirpath.child('banned-ips.json'),
+      bannedPlayers: dirpath.child('banned-players.json'),
+      whitelist: dirpath.child('whitelist.json'),
+      ops: dirpath.child('ops.json'),
+    };
+    this.jsonHandlers = {
+      bannedIps: JsonSourceHandler.fromPath(
+        this.outputPaths.bannedIps,
+        z.array(BannedIp)
+      ),
+      bannedPlayers: JsonSourceHandler.fromPath(
+        this.outputPaths.bannedPlayers,
+        z.array(BannedPlayer)
+      ),
+      whitelist: JsonSourceHandler.fromPath(
+        this.outputPaths.whitelist,
+        z.array(WhitelistPlayer)
+      ),
+      ops: JsonSourceHandler.fromPath(this.outputPaths.ops, z.array(OpPlayer)),
+    };
 
     const settingJson = new Json(World);
 
@@ -88,7 +123,29 @@ export class LocalWorldSource implements WorldContainerHandler {
     if (meta.isErr) return meta;
     const world = meta.value();
 
-    // TODO: ここでデータを展開
+    // データを展開
+    const res = await Promise.all([
+      this.jsonHandlers.bannedIps.write(world.bannedIps),
+      this.jsonHandlers.bannedPlayers.write(world.bannedPlayers),
+      this.jsonHandlers.ops.write(world.players.filter((p) => p.level !== 0)),
+      this.jsonHandlers.whitelist.write(
+        world.players.map(({ name, uuid }) => {
+          return { name, uuid };
+        })
+      ),
+      this.outputPaths.properties.writeText(stringify(world.properties)),
+    ]);
+
+    // エラーがあった場合は展開したファイルを削除
+    const errRes = res.filter((v) => v.isErr);
+    if (errRes.length > 0) {
+      await Promise.all(Object.values(this.outputPaths).map((p) => p.remove()));
+      // エラーは代表して1つ目を返す
+      return errRes[0];
+    }
+
+    // TODO: @txkodo ここの戻り値はこれでOK？
+    return ok(this.dirpath);
   }
 
   packWorldData(name: WorldName): Promise<Result<void>> {

--- a/src-electron/v2/source/world/properties.ts
+++ b/src-electron/v2/source/world/properties.ts
@@ -1,3 +1,161 @@
+import {
+  ServerProperties,
+  ServerPropertiesAnnotation,
+} from '../../schema/serverproperty';
+
+const PORT_MAX = 2 ** 16 - 2;
+
+export const annotations: ServerPropertiesAnnotation = {
+  'allow-flight': { type: 'boolean', default: false },
+
+  'allow-nether': { type: 'boolean', default: true },
+
+  'broadcast-console-to-ops': { type: 'boolean', default: true },
+
+  'broadcast-rcon-to-ops': { type: 'boolean', default: true },
+
+  difficulty: {
+    type: 'string',
+    default: 'easy',
+    enum: ['peaceful', 'easy', 'normal', 'hard'],
+  },
+
+  'enable-command-block': { type: 'boolean', default: false },
+
+  'enable-jmx-monitoring': { type: 'boolean', default: false },
+
+  'enable-rcon': { type: 'boolean', default: false },
+
+  'enable-status': { type: 'boolean', default: true },
+
+  'enable-query': { type: 'boolean', default: false },
+
+  'enforce-secure-profile': { type: 'boolean', default: true },
+
+  'enforce-whitelist': { type: 'boolean', default: false },
+
+  'entity-broadcast-range-percentage': {
+    type: 'number',
+    default: 100,
+    min: 0,
+    max: 500,
+  },
+
+  'force-gamemode': { type: 'boolean', default: false },
+
+  'function-permission-level': { type: 'number', default: 2, min: 1, max: 4 },
+
+  gamemode: {
+    type: 'string',
+    default: 'survival',
+    enum: ['survival', 'creative', 'adventure', 'spectator'],
+  },
+
+  'generate-structures': { type: 'boolean', default: true },
+
+  'generator-settings': { type: 'string', default: '{}' },
+
+  hardcore: { type: 'boolean', default: false },
+
+  'hide-online-players': { type: 'boolean', default: false },
+
+  'initial-disabled-packs': { type: 'string', default: '' },
+
+  'initial-enabled-packs': { type: 'string', default: 'vanilla' },
+
+  // 自動設定のため削除
+  // 'level-name': { type: 'string', default: '' },
+
+  'level-seed': { type: 'string', default: '' },
+
+  'level-type': {
+    type: 'string',
+    default: 'default',
+    enum: ['default', 'flat', 'largeBiomes', 'amplified', 'buffet'],
+  },
+
+  'log-ips': { type: 'boolean', default: true },
+
+  // legacy?
+  'max-build-height': { type: 'number', default: 256, step: 8 },
+
+  'max-chained-neighbor-updates': { type: 'number', default: 1000000 },
+
+  'max-players': { type: 'number', default: 20, min: 0, max: 2 ** 31 - 1 },
+
+  'max-tick-time': {
+    type: 'number',
+    default: 60000,
+    min: 0,
+    max: 2 ** 63 - 1,
+  },
+
+  'max-world-size': {
+    type: 'number',
+    default: 29999984,
+    min: 1,
+    max: 29999984,
+  },
+
+  motd: { type: 'string', default: 'A Minecraft Server' },
+
+  'network-compression-threshold': { type: 'number', default: 256, min: -1 },
+
+  'online-mode': { type: 'boolean', default: true },
+
+  'op-permission-level': { type: 'number', default: 4, min: 1, max: 4 },
+
+  'player-idle-timeout': { type: 'number', default: 0, min: 0 },
+
+  'prevent-proxy-connections': { type: 'boolean', default: false },
+
+  'previews-chat': { type: 'boolean', default: false },
+
+  pvp: { type: 'boolean', default: true },
+
+  'query.port': { type: 'number', default: 25565, min: 1, max: PORT_MAX },
+
+  'rate-limit': { type: 'number', default: 0, min: 0 },
+
+  'rcon.password': { type: 'string', default: '' },
+
+  'rcon.port': { type: 'number', default: 25575, min: 1, max: PORT_MAX },
+
+  'resource-pack': { type: 'string', default: '' },
+
+  'resource-pack-prompt': { type: 'string', default: '' },
+
+  'resource-pack-sha1': { type: 'string', default: '' },
+
+  'require-resource-pack': { type: 'boolean', default: false },
+
+  'server-ip': { type: 'string', default: '' },
+
+  'server-port': { type: 'number', default: 25565, min: 1, max: PORT_MAX },
+
+  'simulation-distance': { type: 'number', default: 10, min: 3, max: 32 },
+
+  'snooper-enabled': { type: 'boolean', default: true },
+
+  'spawn-animals': { type: 'boolean', default: true },
+
+  'spawn-monsters': { type: 'boolean', default: true },
+
+  'spawn-npcs': { type: 'boolean', default: true },
+
+  'spawn-protection': { type: 'number', default: 16, min: 0 },
+
+  'sync-chunk-writes': { type: 'boolean', default: true },
+
+  'text-filtering-config': { type: 'string', default: '' },
+
+  'use-native-transport': { type: 'boolean', default: true },
+
+  'view-distance': { type: 'number', default: 10, min: 2, max: 32 },
+
+  'white-list': { type: 'boolean', default: false },
+};
+
 export const parse = (text: string) => {
   const result: Record<string, string> = {};
   const unescape = (str: string) => {
@@ -25,7 +183,7 @@ export const parse = (text: string) => {
   return result;
 };
 
-export const stringify = (record: Record<string, string>) => {
+export const stringify = (record: ServerProperties) => {
   const lines: string[] = [];
   const entries = Object.entries(record);
   const escape = (str: string) => {
@@ -36,7 +194,7 @@ export const stringify = (record: Record<string, string>) => {
     return str;
   };
   entries.forEach(([key, value]) => {
-    const line = `${escape(key)}=${escape(value)}`;
+    const line = `${escape(key)}=${escape(value.toString())}`;
     lines.push(line);
   });
 

--- a/src-electron/v2/source/world/properties.ts
+++ b/src-electron/v2/source/world/properties.ts
@@ -1,0 +1,78 @@
+export const parse = (text: string) => {
+  const result: Record<string, string> = {};
+  const unescape = (str: string) => {
+    str = str.replaceAll(/\\([=:#!])/g, '$1');
+    str = str.replaceAll('\\n', '\n');
+    str = str.replaceAll('\\t', '\t');
+    str = str.replaceAll('\\\\', '\\');
+    return str;
+  };
+  text.split(/\n|\r/).forEach((line) => {
+    if (line.startsWith('#') || line.startsWith('!')) return;
+    const match = line.matchAll(/(?<!\\)[=:]/g);
+    const matcharray: RegExpExecArray[] = Array.from(match);
+
+    if (matcharray.length !== 1) return;
+
+    const splitIndex = matcharray[0].index;
+    let key = line.slice(0, splitIndex).trim();
+    key = unescape(key);
+    let value = line.slice(splitIndex + 1).trimStart();
+    value = unescape(value);
+
+    result[key] = value;
+  });
+  return result;
+};
+
+export const stringify = (record: Record<string, string>) => {
+  const lines: string[] = [];
+  const entries = Object.entries(record);
+  const escape = (str: string) => {
+    str = str.replaceAll('\\', '\\\\');
+    str = str.replaceAll(/([=:#!])/g, '\\$1');
+    str = str.replaceAll('\n', '\\n');
+    str = str.replaceAll('\t', '\\t');
+    return str;
+  };
+  entries.forEach(([key, value]) => {
+    const line = `${escape(key)}=${escape(value)}`;
+    lines.push(line);
+  });
+
+  return lines.join('\n');
+};
+
+/** In Source Testing */
+if (import.meta.vitest) {
+  const { test, expect } = import.meta.vitest;
+  test('parsetest', () => {
+    expect(parse('a=b')).toEqual({ a: 'b' });
+    expect(parse('a=b\nc=d')).toEqual({ a: 'b', c: 'd' });
+    expect(parse('a=b\r\nc=d')).toEqual({ a: 'b', c: 'd' });
+    expect(parse('a=b\rc=d')).toEqual({ a: 'b', c: 'd' });
+    expect(parse('a=b=c')).toEqual({});
+    expect(parse('a=b=c\nd=e')).toEqual({ d: 'e' });
+    expect(parse('a=b\n#c=d')).toEqual({ a: 'b' });
+    expect(parse('a=b\n!c=d')).toEqual({ a: 'b' });
+    expect(parse(' a =b')).toEqual({ a: 'b' });
+    expect(parse(' a = b ')).toEqual({ a: 'b ' });
+    expect(parse(' a = b c ')).toEqual({ a: 'b c ' });
+    expect(parse('a\\==b')).toEqual({ 'a=': 'b' });
+    expect(parse('a\\=\\==\\=\\=b\\=')).toEqual({ 'a==': '==b=' });
+    expect(parse('a\\:\\:=\\:\\:b\\:')).toEqual({ 'a::': '::b:' });
+    expect(parse('a:b')).toEqual({ a: 'b' });
+    expect(parse('\\\\a:b')).toEqual({ '\\a': 'b' });
+    expect(parse('\\\\\\:\\\\\\=:b')).toEqual({ '\\:\\=': 'b' });
+    expect(parse('\\#\\!:b')).toEqual({ '#!': 'b' });
+    expect(parse('\\n:b')).toEqual({ '\n': 'b' });
+  });
+  test('stringifyTest', () => {
+    expect(stringify({ a: 'b', c: 'd' })).toEqual('a=b\nc=d');
+    expect(stringify({ 'a=': 'b', c: 'd' })).toEqual('a\\==b\nc=d');
+    expect(stringify({ '\\:\\=': 'b' })).toEqual('\\\\\\:\\\\\\==b');
+    expect(stringify({ '#!': 'b' })).toEqual('\\#\\!=b');
+    expect(stringify({ '#!': 'b' })).toEqual('\\#\\!=b');
+    expect(stringify({ '\n': 'b' })).toEqual('\\n=b');
+  });
+}

--- a/src-electron/v2/util/obj/obj.ts
+++ b/src-electron/v2/util/obj/obj.ts
@@ -1,0 +1,24 @@
+export type Entries<T extends Record<PropertyKey, any>> = {
+  [K in keyof T]: [K, T[K]];
+}[keyof T][];
+
+export const toEntries = <T extends Record<string, any>>(
+  object: T
+): Entries<T> => Object.entries(object) as Entries<T>;
+
+export const fromEntries = <T extends Record<PropertyKey, any>>(
+  object: Entries<T>
+): T => Object.fromEntries(object) as T;
+
+/**
+ * obj[]の配列の特定のキーの値をキーとするオブジェクトを返す
+ */
+export function toRecord<T extends { [K in keyof T]: any }, K extends keyof T>(
+  array: T[],
+  selector: K
+): Record<T[K], T> {
+  return array.reduce(
+    (acc, item) => ((acc[item[selector]] = item), acc),
+    {} as Record<T[K], T>
+  );
+}

--- a/src-electron/v2/util/obj/objmap.ts
+++ b/src-electron/v2/util/obj/objmap.ts
@@ -1,0 +1,68 @@
+import { fromEntries, toEntries } from './obj';
+
+// objectに対してmapできるようにする
+export function objMap<K extends string, V, K2 extends string, V2>(
+  object: { [key in K]: V },
+  func: (key: K, value: V, index: number) => [K2, V2]
+): {
+  [key in K2]: V2;
+} {
+  const entries = toEntries(object);
+  const mapped = entries.map(([key, value], index) => func(key, value, index));
+  return fromEntries(mapped);
+}
+
+// objectに対してmapできるようにする
+export function objValueMap<K extends string, V, V2>(
+  object: { [key in K]: V },
+  func: (value: V, key: K, index: number) => V2
+): {
+  [key in K]: V2;
+} {
+  const entries = toEntries(object);
+  const mapped = entries.map(([key, value], index): [K, V2] => [
+    key,
+    func(value, key, index),
+  ]);
+  return fromEntries(mapped);
+}
+
+// objectに対してmapできるようにする
+export function objKeyMap<K extends string, V, K2 extends string>(
+  object: { [key in K]: V },
+  func: (key: K, value: V, index: number) => K2
+): {
+  [key in K2]: V;
+} {
+  const entries = toEntries(object);
+  const mapped = entries.map(([key, value], index): [K2, V] => [
+    func(key, value, index),
+    value,
+  ]);
+  return fromEntries(mapped);
+}
+
+// objectに対してforEachできるようにする
+export function objEach<K extends string, V>(
+  object: { [key in K]: V },
+  func: (key: K, value: V, index: number) => void
+): void {
+  const entries = toEntries(object);
+  entries.forEach(([key, value], index) => func(key, value, index));
+}
+
+// 非同期関数でmapする
+export async function asyncMap<T, U>(
+  values: Readonly<T[]>,
+  func: (value: T, index: number) => Promise<U>
+): Promise<U[]> {
+  return await Promise.all(values.map(func));
+}
+
+// 非同期関数でforEachする
+export async function asyncForEach<T>(
+  values: T[],
+  func: (value: T, index: number) => Promise<void>
+): Promise<void> {
+  await Promise.all(values.map(func));
+}


### PR DESCRIPTION
<!-- このPRはブランチを切った後，直ちに作成し，ブランチ内で変更する箇所を次章に列挙する -->

<!-- PRの作成時にはLabelsとAssignees（担当者）を割り当て，責任の所在を明確にする -->
<!-- PRの内容をすべて実装した際にReviewersを指定して，変更管理の承認を受ける -->

# ワールドの各種設定ファイルの操作

<!-- Pull Requestの概要を２行程度で説明する -->
<!-- このPRはブランチを切った後，直ちに作成し，ブランチ内で変更する箇所を次章に列挙する -->

今回の実装では，ワールドに関連する設定の一切を`server_settings.json`に押し込んでいることから，実際にサーバーを起動するときには，当該データをサーバーJarが読み取る所定のファイルに展開する必要がある．

また，展開したファイルを再度`server_settings.json`に戻す（＝梱包する）必要もあることから，展開と梱包の両者を実装した

作業フォルダ：`src-electron\v2\source\world`

## 変更箇所
<!-- 変更内容を列挙し，小項目は必要に応じて利用する -->
<!-- Issuesから引用する際には「#00 を修正」のように記載し，Developmentに当該Issueを忘れずに登録する -->
- [x] ファイル操作
  - [x] `server_settings.json`から各種ファイルへの展開
  - [x] 各種ファイルから`server_settings.json`への梱包
- [x] ワールドオブジェクトに`properties`の項目を追加
- [x] プロパティの操作を行うUtilを`main`ブランチより導入
- [x] Recordをはじめとしたオブジェクトの操作を行うUtilを現行実装のUtilより導入
- [ ] 上記変更に対するテストを作成


## 承認者への申し送り事項

- 戻り値や`server_settings.json`への書き込み内容が仕様通りかを確認してください．コメントから想定されうる仕様を実装していますが，想定と違うものになっている場合は修正点の指摘をお願いします．
