### PR TITLE
[PR#20] Redmineの自動化プロセスを追加

### DIFF
--- a/.github/workflows/redmine_commit.yml
+++ b/.github/workflows/redmine_commit.yml
@@ -1,0 +1,59 @@
+name: Ref Commit to Redmine
+
+on: 
+  push: 
+
+env:
+  # RedmineのURL
+  TARGET_URL: http://redmine-serverstarter2:3000
+  
+  # RedmineのプロジェクトID
+  # 現在は v2.3.0 のプロジェクトにIssueを立てる設定となっているため，プロジェクト変更時はここを変更する
+  # PROJECT_ID: 2
+  
+  # ステータスの番号（「作業中」の並び順番号を指定）
+  TARGET_STATUS_ID_Progress: 2
+  TARGET_STATUS_ID_Close: 5
+
+jobs:
+  notify_commit:
+    runs-on: ubuntu-latest
+    steps:
+      # Tailescaleは https://zenn.dev/mimi_chan/articles/599841c45b4d49 の記事に従って設定する
+      - name: Connect to Tailscale
+        uses: tailscale/github-action@v2
+        with:
+          oauth-client-id: ${{ secrets.TAILSCALE_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TAILSCALE_OAUTH_CLIENT_SECRET }}
+          tags: tag:ci
+      
+      # pushに含まれるコミットメッセージ一覧を取得
+      - name: Check out repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      # ブランチを切った直後の場合，beforeが存在しないため000...となってしまうことに対する対策
+      - name: Check before commit
+        id: log_arg
+        run: |
+          if [[ "${{ github.event.before }}" == 0000000000000000000000000000000000000000 ]]; then
+            echo "::set-output name=arg::${{ github.event.after }} -1"
+          else
+            echo "::set-output name=arg::${{ github.event.before }}..${{ github.event.after }}"
+          fi
+
+      - name: Get commit messages and Send a message to Redmine
+        run: |
+          commits=$(git log --format=%H ${{ steps.log_arg.outputs.arg }})
+          echo "$commits" | while read -r commit_hash; do
+            cmd='git log --format=%B ${commit_hash} -1'
+            commit_message=$(eval ${cmd})
+            if [[ $commit_message =~ [rR]ef#([0-9]+) ]]; then
+              echo "{\"issue\":{\"status_id\":${{env.TARGET_STATUS_ID_Progress}},\"notes\":\"チケットが [$commit_message](https://github.com/${{github.repository}}/commit/$commit_hash) によって関連付けられました\"}}" > post.json
+              curl -X PUT -H "Content-Type:application/json" -H "X-Redmine-API-Key:${{secrets.REDMINE_API_KEY}}" -d @post.json ${{env.TARGET_URL}}/issues/${BASH_REMATCH[1]}.json
+            elif [[ $commit_message =~ [cC]lose#([0-9]+) ]]; then
+              echo "{\"issue\":{\"status_id\":${{env.TARGET_STATUS_ID_Progress}},\"notes\":\"チケットは [$commit_message](https://github.com/${{github.repository}}/commit/$commit_hash) によって完了しました\"}}" > post.json
+              curl -X PUT -H "Content-Type:application/json" -H "X-Redmine-API-Key:${{secrets.REDMINE_API_KEY}}" -d @post.json ${{env.TARGET_URL}}/issues/${BASH_REMATCH[1]}.json
+            fi
+          done

--- a/.github/workflows/redmine_issue.yml
+++ b/.github/workflows/redmine_issue.yml
@@ -1,0 +1,60 @@
+name: Redmine
+
+on:
+ issues: 
+   types: [opened,closed]
+
+env:
+  # RedmineのURL
+  TARGET_URL: http://redmine-serverstarter2:3000
+  # RedmineのプロジェクトID
+  # ServerStarter2の本体プロジェクトに向けてチケットを発行する
+  PROJECT_ID: 1
+  
+  # ステータスの番号（「ステータスの管理」におけるIdを Dev Tools で確認する）
+  TARGET_STATUS_ID_CLOSED: 5
+  TARGET_STATUS_ID_REJECT: 6
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      # Tailescaleは https://zenn.dev/mimi_chan/articles/599841c45b4d49 の記事に従って設定する
+      - name: Connect to Tailscale
+        uses: tailscale/github-action@v2
+        with:
+          oauth-client-id: ${{ secrets.TAILSCALE_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TAILSCALE_OAUTH_CLIENT_SECRET }}
+          tags: tag:ci
+      
+      # Redmineは env が設定されていれば動く
+      # Issue（Ticket）を作ったことにしたいユーザーの REDMINE_API_KEY をsecretに登録しておく
+      - name: Create new Ticket
+        if: github.event.action == 'opened'
+        run: curl -X POST -H "Content-Type:application/json" -H "X-Redmine-API-Key:${{secrets.REDMINE_API_KEY}}" -d '{"issue":{"project_id":${{env.PROJECT_ID}},"subject":"[Issue#${{github.event.issue.number}}] ${{github.event.issue.title}}","description":"詳細は元のIssuesを参照\n${{github.event.issue.html_url}}","priority_id":2,"tracker_id":1,"status_id":1}}' ${{env.TARGET_URL}}/issues.json
+
+
+      # Issuesが「Not Planned」で閉じられた場合はTicketも却下する
+      - name: Checkout repository
+        if: github.event.action == 'closed'
+        uses: actions/checkout@v2
+
+      - name: Get issues from API
+        if: github.event.action == 'closed'
+        run: |
+          curl -s ${{env.TARGET_URL}}/issues.json -o issues.json
+  
+      - name: Filter issues containing target one
+        if: github.event.action == 'closed'
+        id: ticket_id
+        run: |
+          tmp=$(cat issues.json | jq -r '.issues[] | select(.subject | contains("${{github.event.issue.title}}")) | .id')
+          echo "::set-output name=number::${tmp}"
+      
+      # 実装現在では，「新規」⇒「終了」のステータス遷移は禁止しているため，下記はコメントアウト
+      # - name: Close a ticket
+      #   if: github.event.issue.state_reason == 'completed'
+      #   run: curl -X PUT -H "Content-Type:application/json" -H "X-Redmine-API-Key:${{secrets.REDMINE_API_KEY}}" -d '{"issue":{"status_id":${{env.TARGET_STATUS_ID_CLOSED}}}}' ${{env.TARGET_URL}}/issues/${{steps.ticket_id.outputs.number}}.json
+      - name: Reject a ticket
+        if: github.event.issue.state_reason == 'not_planned'
+        run: curl -X PUT -H "Content-Type:application/json" -H "X-Redmine-API-Key:${{secrets.REDMINE_API_KEY}}" -d '{"issue":{"status_id":${{env.TARGET_STATUS_ID_REJECT}}}}' ${{env.TARGET_URL}}/issues/${{steps.ticket_id.outputs.number}}.json

--- a/.github/workflows/redmine_pull_request.yml
+++ b/.github/workflows/redmine_pull_request.yml
@@ -1,0 +1,118 @@
+name: Pull Request to Redmine
+
+on: 
+  pull_request: 
+    types: [opened,closed]
+  pull_request_review: 
+    types: [submitted,dismissed]
+
+env:
+  # RedmineのURL
+  TARGET_URL: http://redmine-serverstarter2:3000
+  
+  # RedmineのプロジェクトID
+  # 現在は v2.3.0 のプロジェクトにIssueを立てる設定となっているため，プロジェクト変更時はここを変更する
+  # PROJECT_ID: 2
+  
+  # ステータスの番号（「ステータスの管理」におけるIdを Dev Tools で確認する）
+  # ステータスが自動で切り替わらない場合は，「ワークフロー」の設定で当該ステータスから変えようとするステータスへの遷移が許可されているか確認する
+  TARGET_STATUS_ID_Progress: 2
+  TARGET_STATUS_ID_WantCheck: 3
+  TARGET_STATUS_ID_Approve: 7
+  TARGET_STATUS_ID_RequireFix: 8
+  TARGET_STATUS_ID_MERGED: 5
+  TARGET_STATUS_ID_REJECT: 6
+
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+
+jobs:
+  pr_notify:
+    runs-on: ubuntu-latest
+
+    steps:
+      # Tailescaleは https://zenn.dev/mimi_chan/articles/599841c45b4d49 の記事に従って設定する
+      - name: Connect to Tailscale
+        uses: tailscale/github-action@v2
+        with:
+          oauth-client-id: ${{ secrets.TAILSCALE_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TAILSCALE_OAUTH_CLIENT_SECRET }}
+          tags: tag:ci
+
+      # Titleのパース
+      # PRのタイトルで「PR#00 タイトル」のようにしたとき，チケット番号である#00の数値を抽出
+      - name: Parse PR Title
+        id: ticket_id
+        run: |
+          if [[ "${{github.event.pull_request.title}}" =~ PR#([0-9]+) ]]; then
+            echo "::set-output name=number::${BASH_REMATCH[1]}"
+          else
+            echo "::set-output name=number::0"
+          fi
+
+      # Redmine側のタイトルを取得する
+      - name: Get Redmine Title
+        run: |
+          curl -H "Accept: application/json" ${{env.TARGET_URL}}/issues/${{steps.ticket_id.outputs.number}}.json -o data.json
+      # Redmine側のチケットのタイトルにある「Issues#00」のうち，#00の数値を抽出
+      - name: Parse Ticket Title
+        id: issue_id
+        run: |
+          if [[ $(jq .issue.subject data.json) =~ Issue#([0-9]+) ]]; then
+            echo "::set-output name=number::${BASH_REMATCH[1]}"
+          else
+            echo "::set-output name=number::0"
+          fi
+
+      # pull requestが開かれたことを受けて，Ticketのステータスを「承認待ち」に変更する
+      - name: Send pr info to redmine
+        if: github.event.action == 'opened' && steps.ticket_id.outputs.number != 0
+        run: |
+          curl -X PUT -H "Content-Type:application/json" -H "X-Redmine-API-Key:${{secrets.REDMINE_API_KEY}}" -d '{"issue":{"status_id":${{env.TARGET_STATUS_ID_WantCheck}},"notes":"Pull Request [${{github.event.pull_request.title}}](${{github.event.pull_request._links.html.href}}) is opened"}}' ${{env.TARGET_URL}}/issues/${{steps.ticket_id.outputs.number}}.json
+      - name: Set comment for related issue
+        if: github.event.action == 'opened' && steps.issue_id.outputs.number != 0
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ steps.issue_id.outputs.number }}
+          body: |
+            このIssueは #${{github.event.pull_request.number}} によって修正予定です
+
+      
+      # ステータスを「マージ待ち」に進める
+      - name: Send pr info to redmine
+        if: github.event.action == 'submitted' && steps.ticket_id.outputs.number != 0
+        run: |
+          curl -X PUT -H "Content-Type:application/json" -H "X-Redmine-API-Key:${{secrets.REDMINE_API_KEY}}" -d '{"issue":{"status_id":${{env.TARGET_STATUS_ID_Approve}}}}' ${{env.TARGET_URL}}/issues/${{steps.ticket_id.outputs.number}}.json
+      
+
+      # ステータスを「修正要求」に進める
+      - name: Send pr info to redmine
+        if: github.event.action == 'submitted' && steps.ticket_id.outputs.number != 0
+        run: |
+          curl -X PUT -H "Content-Type:application/json" -H "X-Redmine-API-Key:${{secrets.REDMINE_API_KEY}}" -d '{"issue":{"status_id":${{env.TARGET_STATUS_ID_RequireFix}}}}' ${{env.TARGET_URL}}/issues/${{steps.ticket_id.outputs.number}}.json
+
+
+      # ステータスを「終了」に進める
+      - name: Send pr info to redmine (pr is closed)
+        if: github.event.action == 'closed' && steps.ticket_id.outputs.number != 0 && github.event.pull_request.merged == true
+        run: |
+          curl -X PUT -H "Content-Type:application/json" -H "X-Redmine-API-Key:${{secrets.REDMINE_API_KEY}}" -d '{"issue":{"status_id":${{env.TARGET_STATUS_ID_MERGED}}}}' ${{env.TARGET_URL}}/issues/${{steps.ticket_id.outputs.number}}.json
+      # ステータスを「却下」に進める
+      - name: Send pr info to redmine (pr is rejected)
+        if: github.event.action == 'closed' && steps.ticket_id.outputs.number != 0 && github.event.pull_request.merged == false
+        run: |
+          curl -X PUT -H "Content-Type:application/json" -H "X-Redmine-API-Key:${{secrets.REDMINE_API_KEY}}" -d '{"issue":{"status_id":${{env.TARGET_STATUS_ID_REJECT}}}}' ${{env.TARGET_URL}}/issues/${{steps.ticket_id.outputs.number}}.json
+      # 関連するIssueを閉じる
+      - name: Close a related issue
+        if: github.event.action == 'closed' && steps.issue_id.outputs.number != 0
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            await github.rest.issues.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: ${{steps.issue_id.outputs.number}},
+              state: 'closed'
+            });


### PR DESCRIPTION
<!-- このPRはブランチを切った後，直ちに作成し，ブランチ内で変更する箇所を次章に列挙する -->

<!-- PRの作成時にはLabelsとAssignees（担当者）を割り当て，責任の所在を明確にする -->
<!-- PRの内容をすべて実装した際にReviewersを指定して，変更管理の承認を受ける -->

# Redmine自動化

Redmineにおけるチケット管理とGitHubにおけるIssues，Pull Requestの整合性を保持する自動化コードを追加



## 実装した機能
<!-- 変更内容を列挙し，小項目は必要に応じて利用する -->
<!-- Issuesから引用する際には「#00 を修正」のように記載し，Developmentに当該Issueを忘れずに登録する -->
- コミットとチケットを連携
  - コミットメッセージに`ref#00`や`close#00`のようにチケット番号とキーワードを入れると，チケットに当該コミットが表示される
  - `close#00`の場合はチケットを「終了」のステータスにできる（Pull Requestに直結しない子チケット以下での利用を想定）
- Issueの発行とチケットの発行を連携
  - 基本的な作業開始時にはチケットの発行のみとなるが，一般からのIssuesやバグ告知としてのIssuesの立ち上げがあった際には対応するチケットが自動的に発行される
  - チケット発行時は「新規」のステータスで発行される
  - Issuesが「Not Planned」で閉じられた際には，対応するチケットも「却下」として終了する
- Pull Requestとチケットの連携
  - PRのタイトルに`PR#00`のようにチケット番号とキーワードを入れると，チケットのステータスが「承認待ち」として記録される
  - PRとチケットが連携することで，チケットに紐づけられたIssueにPRの出現を示すメッセージが送信される
  - PRが承認または修正依頼された際には当該ステータスをチケットにも付与する
  - PRがマージされた際にはチケットは「終了」のステータスとなり，チケットに紐づけられたIssueも閉じられる



## 承認者への申し送り事項

- [作成時のサンプルリポジトリ](https://github.com/CivilTT/ServerStarter2)にて作成しています．
基本的にはそのまま承認でOKですが，もし興味があれば覗いてください
