### PR TITLE
[PR#55] PRとIssuesの自動紐づけ機能を修正

### DIFF
--- a/.github/workflows/redmine_pull_request.yml
+++ b/.github/workflows/redmine_pull_request.yml
@@ -73,7 +73,7 @@ jobs:
         if: github.event.action == 'opened' && steps.issue_id.outputs.number != 0
         uses: peter-evans/create-or-update-comment@v1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.CIVILTT_PERSONAL_ACCESS_TOKEN }}
           issue-number: ${{ steps.issue_id.outputs.number }}
           body: |
             このIssueは #${{github.event.pull_request.number}} によって修正予定です
@@ -108,7 +108,7 @@ jobs:
         if: github.event.action == 'closed' && steps.issue_id.outputs.number != 0
         uses: actions/github-script@v6
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.CIVILTT_PERSONAL_ACCESS_TOKEN }}
           script: |
             await github.rest.issues.update({
               owner: context.repo.owner,


### PR DESCRIPTION
<!-- このPRはブランチを切った後，直ちに作成し，ブランチ内で変更する箇所を次章に列挙する -->

<!-- PRの作成時にはLabelsとAssignees（担当者）を割り当て，責任の所在を明確にする -->
<!-- PRの内容をすべて実装した際にReviewersを指定して，変更管理の承認を受ける -->

# PRとIssuesの自動紐づけ機能を修正

PRが出された際，関連するRedmineチケットに紐づけられている場合，チケットに紐づいたIssuesにもPRが紐づくはずであるが，現状ではうまく動作していない

紐づけに用いるTokenをPATに変更することで対応
