### PR TITLE
プロパティのパース処理を変更

### DIFF
--- a/src-electron/schema/serverproperty.ts
+++ b/src-electron/schema/serverproperty.ts
@@ -120,7 +120,7 @@ const DefaultServerProperties = z
     'resource-pack-id': stringSetter(''),
     'resource-pack-prompt': stringSetter(''),
     'resource-pack-sha1': stringSetter(''),
-    'reqire-resource-pack': boolSetter(false),
+    'require-resource-pack': boolSetter(false),
     'server-ip': stringSetter(''),
     'server-port': numberSetter(25565, 1, PORT_MAX, 1),
     'simulation-distance': numberSetter(10, 3, 32, 1),

--- a/src-electron/schema/serverproperty.ts
+++ b/src-electron/schema/serverproperty.ts
@@ -93,6 +93,7 @@ const DefaultServerProperties = z
       ['default', 'flat', 'largeBiomes', 'amplified', 'buffet'],
       'default'
     ),
+    'log-ips': boolSetter(true),
     // legacy?
     'max-build-height': numberSetter(256, undefined, undefined, 8),
     'max-chained-neighbor-updates': numberSetter(1000000),

--- a/src-electron/schema/serverproperty.ts
+++ b/src-electron/schema/serverproperty.ts
@@ -1,7 +1,269 @@
 import { z } from 'zod';
-import { objValueMap } from 'app/src-public/scripts/obj/objmap';
 
 const PORT_MAX = 2 ** 16 - 2;
+
+const boolSetter = (def: boolean) => z.coerce.boolean().default(def).catch(def);
+const stringSetter = (def: string) => z.string().default(def).catch(def);
+const enumSetter = <U extends string, T extends Readonly<[U, ...U[]]>>(
+  values: T,
+  def: T[number]
+) => z.enum(values).default(def).catch(def);
+const numberSetter = (
+  def: number,
+  min?: number,
+  max?: number,
+  step?: number
+) => {
+  const numType = z.number();
+  if (min !== undefined) numType.min(min);
+  if (max !== undefined) numType.max(max);
+  if (step !== undefined) numType.step(step);
+  return numType.default(def).catch(def);
+};
+
+/** 標準登録のサーバープロパティ */
+const DefaultServerProperties = z
+  .object({
+    'accepts-transfers': boolSetter(false),
+    'allow-flight': boolSetter(false),
+    'allow-nether': boolSetter(true),
+    'broadcast-console-to-ops': boolSetter(true),
+    'broadcast-rcon-to-ops': boolSetter(true),
+    difficulty: enumSetter(['peaceful', 'easy', 'normal', 'hard'], 'easy'),
+    'enable-command-block': boolSetter(false),
+    'enable-jmx-monitoring': boolSetter(false),
+    'enable-query': boolSetter(false),
+    'enable-rcon': boolSetter(false),
+    'enforce-whitelist': boolSetter(false),
+    'entity-broadcast-range-percentage': numberSetter(100, 0, 500),
+    'force-gamemode': boolSetter(false),
+    'function-permission-level': numberSetter(2, 1, 4, 1),
+    gamemode: enumSetter(
+      ['survival', 'creative', 'adventure', 'spectator'],
+      'survival'
+    ),
+    'generate-structures': boolSetter(true),
+    'generator-settings': stringSetter('{}'),
+    hardcore: boolSetter(false),
+    'hide-online-players': boolSetter(false),
+    // 自動設定のため削除
+    // 'level-name': stringSetter('world'),
+    'level-seed': stringSetter(''),
+    // TODO: CUROIDのようなMODが任意のLevelType入力を要求するため，「その他」のような入力項目を追加する
+    'level-type': enumSetter(
+      ['default', 'flat', 'largeBiomes', 'amplified', 'buffet'],
+      'default'
+    ),
+    // legacy?
+    'max-build-height': numberSetter(256, undefined, undefined, 8),
+    'max-chained-neighbor-updates': numberSetter(1000000),
+    'max-players': numberSetter(20, 0, 2 ** 31 - 1),
+    'max-tick-time': numberSetter(60000, 0, 2 ** 63 - 1),
+    'max-world-size': numberSetter(29999984, 1, 29999984),
+    motd: stringSetter('A Minecraft Server'),
+    'network-compression-threshold': numberSetter(256, -1),
+    'online-mode': boolSetter(true),
+    'op-permission-level': numberSetter(4, 1, 4, 1),
+    'player-idle-timeout': numberSetter(0, 0),
+    'prevent-proxy-connections': boolSetter(false),
+    'previews-chat': boolSetter(false),
+    pvp: boolSetter(true),
+    'query.port': numberSetter(25565, 1, PORT_MAX, 1),
+    'rate-limit': numberSetter(0, 0),
+    'rcon.password': stringSetter(''),
+    'rcon.port': numberSetter(25575, 1, PORT_MAX, 1),
+    'region-file-compression': enumSetter(
+      ['deflate', 'lz4', 'none'],
+      'deflate'
+    ),
+    'resource-pack': stringSetter(''),
+    'resource-pack-id': stringSetter(''),
+    'resource-pack-prompt': stringSetter(''),
+    'resource-pack-sha1': stringSetter(''),
+    'reqire-resource-pack': boolSetter(false),
+    'server-ip': stringSetter(''),
+    'server-port': numberSetter(25565, 1, PORT_MAX, 1),
+    'simulation-distance': numberSetter(10, 3, 32, 1),
+    'snooper-enabled': boolSetter(true),
+    'spawn-animals': boolSetter(true),
+    'spawn-monsters': boolSetter(true),
+    'spawn-npcs': boolSetter(true),
+    'spawn-protection': numberSetter(16, 0, undefined, 1),
+    'sync-chunk-writes': boolSetter(true),
+    'text-filtering-config': stringSetter(''),
+    'use-native-transport': boolSetter(true),
+    'view-distance': numberSetter(10, 2, 32, 1),
+    'white-list': boolSetter(false),
+  })
+  .catchall(z.string().or(z.number()).or(z.boolean()));
+
+// export const ServerPropertiesAnnotation = z
+//   .record(ServerPropertyAnnotation)
+//   .default({
+//     'accepts-transfers': { type: 'boolean', default: false },
+
+//     'allow-flight': { type: 'boolean', default: false },
+
+//     'allow-nether': { type: 'boolean', default: true },
+
+//     'broadcast-console-to-ops': { type: 'boolean', default: true },
+
+//     'broadcast-rcon-to-ops': { type: 'boolean', default: true },
+
+//     difficulty: {
+//       type: 'string',
+//       default: 'easy',
+//       enum: ['peaceful', 'easy', 'normal', 'hard'],
+//     },
+
+//     'enable-command-block': { type: 'boolean', default: false },
+
+//     'enable-jmx-monitoring': { type: 'boolean', default: false },
+
+//     'enable-rcon': { type: 'boolean', default: false },
+
+//     'enable-status': { type: 'boolean', default: true },
+
+//     'enable-query': { type: 'boolean', default: false },
+
+//     'enforce-secure-profile': { type: 'boolean', default: true },
+
+//     'enforce-whitelist': { type: 'boolean', default: false },
+
+//     'entity-broadcast-range-percentage': {
+//       type: 'number',
+//       default: 100,
+//       min: 0,
+//       max: 500,
+//     },
+
+//     'force-gamemode': { type: 'boolean', default: false },
+
+//     'function-permission-level': { type: 'number', default: 2, min: 1, max: 4 },
+
+//     gamemode: {
+//       type: 'string',
+//       default: 'survival',
+//       enum: ['survival', 'creative', 'adventure', 'spectator'],
+//     },
+
+//     'generate-structures': { type: 'boolean', default: true },
+
+//     'generator-settings': { type: 'string', default: '{}' },
+
+//     hardcore: { type: 'boolean', default: false },
+
+//     'hide-online-players': { type: 'boolean', default: false },
+
+//     'initial-disabled-packs': { type: 'string', default: '' },
+
+//     'initial-enabled-packs': { type: 'string', default: 'vanilla' },
+
+//     // 自動設定のため削除
+//     // 'level-name': { type: 'string', default: '' },
+
+//     'level-seed': { type: 'string', default: '' },
+
+//     'level-type': {
+//       type: 'string',
+//       default: 'default',
+//       enum: ['default', 'flat', 'largeBiomes', 'amplified', 'buffet'],
+//     },
+
+//     'log-ips': { type: 'boolean', default: true },
+
+//     // legacy?
+//     'max-build-height': { type: 'number', default: 256, step: 8 },
+
+//     'max-chained-neighbor-updates': { type: 'number', default: 1000000 },
+
+//     'max-players': { type: 'number', default: 20, min: 0, max: 2 ** 31 - 1 },
+
+//     'max-tick-time': {
+//       type: 'number',
+//       default: 60000,
+//       min: 0,
+//       max: 2 ** 63 - 1,
+//     },
+
+//     'max-world-size': {
+//       type: 'number',
+//       default: 29999984,
+//       min: 1,
+//       max: 29999984,
+//     },
+
+//     motd: { type: 'string', default: 'A Minecraft Server' },
+
+//     'network-compression-threshold': { type: 'number', default: 256, min: -1 },
+
+//     'online-mode': { type: 'boolean', default: true },
+
+//     'op-permission-level': { type: 'number', default: 4, min: 1, max: 4 },
+
+//     'player-idle-timeout': { type: 'number', default: 0, min: 0 },
+
+//     'prevent-proxy-connections': { type: 'boolean', default: false },
+
+//     'previews-chat': { type: 'boolean', default: false },
+
+//     pvp: { type: 'boolean', default: true },
+
+//     'query.port': { type: 'number', default: 25565, min: 1, max: PORT_MAX },
+
+//     'rate-limit': { type: 'number', default: 0, min: 0 },
+
+//     'rcon.password': { type: 'string', default: '' },
+
+//     'rcon.port': { type: 'number', default: 25575, min: 1, max: PORT_MAX },
+
+//     'region-file-compression': {
+//       type: 'string',
+//       default: 'deflate',
+//       enum: ['deflate', 'lz4', 'none'],
+//     },
+
+//     'resource-pack': { type: 'string', default: '' },
+
+//     'resource-pack-id': { type: 'string', default: '' },
+
+//     'resource-pack-prompt': { type: 'string', default: '' },
+
+//     'resource-pack-sha1': { type: 'string', default: '' },
+
+//     'require-resource-pack': { type: 'boolean', default: false },
+
+//     'server-ip': { type: 'string', default: '' },
+
+//     'server-port': { type: 'number', default: 25565, min: 1, max: PORT_MAX },
+
+//     'simulation-distance': { type: 'number', default: 10, min: 3, max: 32 },
+
+//     'snooper-enabled': { type: 'boolean', default: true },
+
+//     'spawn-animals': { type: 'boolean', default: true },
+
+//     'spawn-monsters': { type: 'boolean', default: true },
+
+//     'spawn-npcs': { type: 'boolean', default: true },
+
+//     'spawn-protection': { type: 'number', default: 16, min: 0 },
+
+//     'sync-chunk-writes': { type: 'boolean', default: true },
+
+//     'text-filtering-config': { type: 'string', default: '' },
+
+//     'use-native-transport': { type: 'boolean', default: true },
+
+//     'view-distance': { type: 'number', default: 10, min: 2, max: 32 },
+
+//     'white-list': { type: 'boolean', default: false },
+//   });
+
+/** サーバープロパティのデータ */
+// export const ServerProperties = DefaultServerProperties.default({});
+export const ServerProperties = DefaultServerProperties.default({});
+export type ServerProperties = z.infer<typeof ServerProperties>;
 
 export const StringServerPropertyAnnotation = z.object({
   type: z.literal('string'),
@@ -36,179 +298,23 @@ export type NumberServerPropertyAnnotation = z.infer<
 >;
 
 export const ServerPropertyAnnotation = StringServerPropertyAnnotation.or(
-  BooleanServerPropertyAnnotation.or(NumberServerPropertyAnnotation)
-);
+  BooleanServerPropertyAnnotation
+).or(NumberServerPropertyAnnotation);
 export type ServerPropertyAnnotation = z.infer<typeof ServerPropertyAnnotation>;
 
 /** サーバープロパティのアノテーション */
-export const ServerPropertiesAnnotation = z
-  .record(ServerPropertyAnnotation)
-  .default({
-    'accepts-transfers': { type: 'boolean', default: false },
-
-    'allow-flight': { type: 'boolean', default: false },
-
-    'allow-nether': { type: 'boolean', default: true },
-
-    'broadcast-console-to-ops': { type: 'boolean', default: true },
-
-    'broadcast-rcon-to-ops': { type: 'boolean', default: true },
-
-    difficulty: {
-      type: 'string',
-      default: 'easy',
-      enum: ['peaceful', 'easy', 'normal', 'hard'],
-    },
-
-    'enable-command-block': { type: 'boolean', default: false },
-
-    'enable-jmx-monitoring': { type: 'boolean', default: false },
-
-    'enable-rcon': { type: 'boolean', default: false },
-
-    'enable-status': { type: 'boolean', default: true },
-
-    'enable-query': { type: 'boolean', default: false },
-
-    'enforce-secure-profile': { type: 'boolean', default: true },
-
-    'enforce-whitelist': { type: 'boolean', default: false },
-
-    'entity-broadcast-range-percentage': {
-      type: 'number',
-      default: 100,
-      min: 0,
-      max: 500,
-    },
-
-    'force-gamemode': { type: 'boolean', default: false },
-
-    'function-permission-level': { type: 'number', default: 2, min: 1, max: 4 },
-
-    gamemode: {
-      type: 'string',
-      default: 'survival',
-      enum: ['survival', 'creative', 'adventure', 'spectator'],
-    },
-
-    'generate-structures': { type: 'boolean', default: true },
-
-    'generator-settings': { type: 'string', default: '{}' },
-
-    hardcore: { type: 'boolean', default: false },
-
-    'hide-online-players': { type: 'boolean', default: false },
-
-    'initial-disabled-packs': { type: 'string', default: '' },
-
-    'initial-enabled-packs': { type: 'string', default: 'vanilla' },
-
-    // 自動設定のため削除
-    // 'level-name': { type: 'string', default: '' },
-
-    'level-seed': { type: 'string', default: '' },
-
-    'level-type': {
-      type: 'string',
-      default: 'default',
-      enum: ['default', 'flat', 'largeBiomes', 'amplified', 'buffet'],
-    },
-
-    'log-ips': { type: 'boolean', default: true },
-
-    // legacy?
-    'max-build-height': { type: 'number', default: 256, step: 8 },
-
-    'max-chained-neighbor-updates': { type: 'number', default: 1000000 },
-
-    'max-players': { type: 'number', default: 20, min: 0, max: 2 ** 31 - 1 },
-
-    'max-tick-time': {
-      type: 'number',
-      default: 60000,
-      min: 0,
-      max: 2 ** 63 - 1,
-    },
-
-    'max-world-size': {
-      type: 'number',
-      default: 29999984,
-      min: 1,
-      max: 29999984,
-    },
-
-    motd: { type: 'string', default: 'A Minecraft Server' },
-
-    'network-compression-threshold': { type: 'number', default: 256, min: -1 },
-
-    'online-mode': { type: 'boolean', default: true },
-
-    'op-permission-level': { type: 'number', default: 4, min: 1, max: 4 },
-
-    'player-idle-timeout': { type: 'number', default: 0, min: 0 },
-
-    'prevent-proxy-connections': { type: 'boolean', default: false },
-
-    'previews-chat': { type: 'boolean', default: false },
-
-    pvp: { type: 'boolean', default: true },
-
-    'query.port': { type: 'number', default: 25565, min: 1, max: PORT_MAX },
-
-    'rate-limit': { type: 'number', default: 0, min: 0 },
-
-    'rcon.password': { type: 'string', default: '' },
-
-    'rcon.port': { type: 'number', default: 25575, min: 1, max: PORT_MAX },
-
-    'region-file-compression': {
-      type: 'string',
-      default: 'deflate',
-      enum: ['deflate', 'lz4', 'none'],
-    },
-
-    'resource-pack': { type: 'string', default: '' },
-
-    'resource-pack-id': { type: 'string', default: '' },
-
-    'resource-pack-prompt': { type: 'string', default: '' },
-
-    'resource-pack-sha1': { type: 'string', default: '' },
-
-    'require-resource-pack': { type: 'boolean', default: false },
-
-    'server-ip': { type: 'string', default: '' },
-
-    'server-port': { type: 'number', default: 25565, min: 1, max: PORT_MAX },
-
-    'simulation-distance': { type: 'number', default: 10, min: 3, max: 32 },
-
-    'snooper-enabled': { type: 'boolean', default: true },
-
-    'spawn-animals': { type: 'boolean', default: true },
-
-    'spawn-monsters': { type: 'boolean', default: true },
-
-    'spawn-npcs': { type: 'boolean', default: true },
-
-    'spawn-protection': { type: 'number', default: 16, min: 0 },
-
-    'sync-chunk-writes': { type: 'boolean', default: true },
-
-    'text-filtering-config': { type: 'string', default: '' },
-
-    'use-native-transport': { type: 'boolean', default: true },
-
-    'view-distance': { type: 'number', default: 10, min: 2, max: 32 },
-
-    'white-list': { type: 'boolean', default: false },
-  });
+export const ServerPropertiesAnnotation = z.record(
+  z.string(),
+  ServerPropertyAnnotation
+);
 export type ServerPropertiesAnnotation = z.infer<
   typeof ServerPropertiesAnnotation
 >;
 
-/** サーバープロパティのデータ */
-export const ServerProperties = z
-  .record(z.string().or(z.number().or(z.boolean())))
-  .default(objValueMap(ServerPropertiesAnnotation.parse({}), (x) => x.default));
-export type ServerProperties = z.infer<typeof ServerProperties>;
+/** In Source Testing */
+if (import.meta.vitest) {
+  const { test, expect } = import.meta.vitest;
+  test('serverProperty_anotations', () => {
+    // console.log(DefaultServerProperties);
+  });
+}

--- a/src-electron/schema/static.ts
+++ b/src-electron/schema/static.ts
@@ -5,7 +5,10 @@ import {
   MOD_CACHE_PATH,
   PLUGIN_CACHE_PATH,
 } from '../source/const';
-import { ServerPropertiesAnnotation } from './serverproperty';
+import {
+  DefaultServerPropertiesAnnotation,
+  ServerPropertiesAnnotation,
+} from './serverproperty';
 
 export const MinecraftColors = z
   .object({
@@ -30,7 +33,9 @@ export const MinecraftColors = z
 export type MinecraftColors = z.infer<typeof MinecraftColors>;
 
 export const StaticResouce = z.object({
-  properties: ServerPropertiesAnnotation,
+  properties: ServerPropertiesAnnotation.default(
+    DefaultServerPropertiesAnnotation
+  ),
   minecraftColors: MinecraftColors,
   paths: z
     .object({

--- a/src-electron/source/system/resource.ts
+++ b/src-electron/source/system/resource.ts
@@ -4,3 +4,41 @@ import { StaticResouce } from '../../schema/static';
 export async function getStaticResoure() {
   return StaticResouce.parse({});
 }
+
+/** In Source Testing */
+if (import.meta.vitest) {
+  const { test, expect } = import.meta.vitest;
+  test('static_resource', async () => {
+    const staticResources = await getStaticResoure();
+    
+    // colors
+    expect(staticResources.minecraftColors.aqua).toBe('#55FFFF');
+    
+    // properties
+    expect(
+      staticResources.properties['white-list']
+    ).toMatchObject({
+      default: false,
+      type: 'boolean',
+    });
+    expect(
+      staticResources.properties['function-permission-level']
+    ).toMatchObject({
+      default: 2,
+      max: 4,
+      min: 1,
+      step: 1,
+      type: 'number',
+    });
+    expect(
+      staticResources.properties['difficulty']
+    ).toMatchObject({
+      default: 'easy',
+      enum: ['peaceful', 'easy', 'normal', 'hard'],
+      type: 'string',
+    });
+
+    // paths
+    expect(staticResources.paths.log.endsWith('log')).toBe(true);
+  });
+}

--- a/src-electron/source/world/files/properties.ts
+++ b/src-electron/source/world/files/properties.ts
@@ -86,12 +86,18 @@ if (import.meta.vitest) {
   const { test, expect } = import.meta.vitest;
 
   test('server_property_parse', () => {
-    // bool test
-    const boolTest = parse('allow-nether=true');
-    expect(Object.hasOwn(boolTest, 'allow-nether')).toBe(true);
-    const boolValue = boolTest['allow-nether'];
-    expect(boolValue).toBe(true);
-    expect(typeof boolValue).toBe('boolean');
+    // bool test (true)
+    const boolTest_true = parse('allow-nether=true');
+    expect(Object.hasOwn(boolTest_true, 'allow-nether')).toBe(true);
+    const boolValue_true = boolTest_true['allow-nether'];
+    expect(boolValue_true).toBe(true);
+    expect(typeof boolValue_true).toBe('boolean');
+    // bool test (false <-- check 'false' > false parse process)
+    const boolTest_false = parse('white-list=false');
+    expect(Object.hasOwn(boolTest_false, 'white-list')).toBe(true);
+    const boolValue_false = boolTest_false['white-list'];
+    expect(boolValue_false).toBe(false);
+    expect(typeof boolValue_false).toBe('boolean');
 
     // enum test
     const enumTest = parse('gamemode=survival');

--- a/src-electron/source/world/files/properties.ts
+++ b/src-electron/source/world/files/properties.ts
@@ -1,7 +1,4 @@
-import {
-  ServerProperties,
-  ServerPropertiesAnnotation,
-} from 'app/src-electron/schema/serverproperty';
+import { ServerProperties } from 'app/src-electron/schema/serverproperty';
 import { isError } from 'app/src-electron/util/error/error';
 import * as properties from 'app/src-electron/util/format/properties';
 import { objValueMap } from 'app/src-electron/util/obj/objmap';
@@ -9,33 +6,33 @@ import { ServerSettingFile } from './base';
 
 /** server.propertiesの中身(string)をパースする */
 const parse = (text: string) => {
-  const propertiy: ServerProperties = {};
-  const record = properties.parse(text);
-  Object.entries(record).forEach(([key, value]) => {
-    const defult = ServerPropertiesAnnotation.parse(undefined)[key];
+  // const propertiy: ServerProperties = ServerProperties.parse({});
+  // const record = properties.parse(text);
+  // Object.entries(record).forEach(([key, value]) => {
+  //   // const defult = ServerPropertiesAnnotation.parse(undefined)[key];
 
-    let prop: string | number | boolean;
+  //   let prop: string | number | boolean;
 
-    if (defult !== undefined) {
-      // 既知のサーバープロパティの場合
-      switch (defult.type) {
-        case 'string':
-          prop = value;
-          break;
-        case 'boolean':
-          prop = value.toLowerCase() === 'true';
-          break;
-        case 'number':
-          prop = Number.parseInt(value);
-          break;
-      }
-    } else {
-      // 未知のサーバープロパティの場合stringとして扱う
-      prop = value;
-    }
-    propertiy[key] = prop;
-  });
-  return propertiy;
+  //   if (defult !== undefined) {
+  //     // 既知のサーバープロパティの場合
+  //     switch (defult.type) {
+  //       case 'string':
+  //         prop = value;
+  //         break;
+  //       case 'boolean':
+  //         prop = value.toLowerCase() === 'true';
+  //         break;
+  //       case 'number':
+  //         prop = Number.parseInt(value);
+  //         break;
+  //     }
+  //   } else {
+  //     // 未知のサーバープロパティの場合stringとして扱う
+  //     prop = value;
+  //   }
+  //   propertiy[key] = prop;
+  // });
+  return ServerProperties.parse(properties.parse(text));
 };
 
 const stringify = (record: ServerProperties) => {
@@ -90,35 +87,40 @@ if (import.meta.vitest) {
 
   test('server_property_parse', () => {
     // bool test
-    const boolTest = parse('allow-nether=false');
-    const boolKey = Object.keys(boolTest)[0];
-    const boolValue = Object.values(boolTest)[0];
-    expect(boolKey).toBe('allow-nether');
-    expect(boolValue).toBe(false);
+    const boolTest = parse('allow-nether=true');
+    expect(Object.hasOwn(boolTest, 'allow-nether')).toBe(true);
+    const boolValue = boolTest['allow-nether'];
+    expect(boolValue).toBe(true);
     expect(typeof boolValue).toBe('boolean');
 
     // enum test
     const enumTest = parse('gamemode=survival');
-    const enumKey = Object.keys(enumTest)[0];
-    const enumValue = Object.values(enumTest)[0];
-    expect(enumKey).toBe('gamemode');
+    expect(Object.hasOwn(enumTest, 'gamemode')).toBe(true);
+    const enumValue = enumTest['gamemode'];
     expect(enumValue).toBe('survival');
     expect(typeof enumValue).toBe('string');
 
     // number test
     const numberTest = parse('max-tick-time=60000');
-    const numberKey = Object.keys(numberTest)[0];
-    const numberValue = Object.values(numberTest)[0];
-    expect(numberKey).toBe('max-tick-time');
+    expect(Object.hasOwn(numberTest, 'max-tick-time')).toBe(true);
+    const numberValue = numberTest['max-tick-time'];
     expect(numberValue).toBe(60000);
     expect(typeof numberValue).toBe('number');
 
     // number checks test (if it doesn't use Zod, this test is ineffective)
     const numberCheckTest = parse('function-permission-level=5'); // invalid setting
-    const numberCheckKey = Object.keys(numberCheckTest)[0];
-    const numberCheckValue = Object.values(numberCheckTest)[0];
-    expect(numberCheckKey).toBe('function-permission-level');
-    expect(numberCheckValue).toBe(5);
+    expect(Object.hasOwn(numberCheckTest, 'function-permission-level')).toBe(
+      true
+    );
+    const numberCheckValue = numberCheckTest['function-permission-level'];
+    expect(numberCheckValue).toBe(2); // overwrote default value
     expect(typeof numberCheckValue).toBe('number');
+
+    // unsupported prop test
+    const unsupportedTest = parse('unsupported-prop=test_value');
+    expect(Object.hasOwn(unsupportedTest, 'unsupported-prop')).toBe(true);
+    const unsupportedValue = unsupportedTest['unsupported-prop'];
+    expect(unsupportedValue).toBe('test_value');
+    expect(typeof unsupportedValue).toBe('string');
   });
 }

--- a/src-public/scripts/obj/obj.ts
+++ b/src-public/scripts/obj/obj.ts
@@ -10,7 +10,7 @@ export const fromEntries = <T extends Record<PropertyKey, any>>(
   object: Entries<T>
 ): T => Object.fromEntries(object) as T;
 
-export const keys = <K extends string | number | symbol, V>(
+export const keys = <K extends string, V>(
   object: Record<K, V>
 ): K[] => Object.keys(object) as K[];
 


### PR DESCRIPTION
# 概要

`server.properties`ファイルから取得したデータに関するパース処理を修正

プロパティ関連の処理をV2側に準拠した内容へ修正し，プロパティ定義を統合した


## 変更概要
- [x] プロパティのパース処理をZodに置換
- [x] `log-ips`のデフォルト値を設定
- [ ] `resource-pack`等の任意文字列を受ける項目において，一定の文字数を上回る文字列が入力された際に入力結果がリセットされる問題を修正
- [ ] `level-type`のようなEnum要素について，その他の文字列を受けられるように修正