### PR TITLE
Pathの実装をV2より移築

### DIFF
--- a/src-electron/common/logger.ts
+++ b/src-electron/common/logger.ts
@@ -191,47 +191,50 @@ const handler: ProxyHandler<LoggerHierarchy> = {
 
 /** In Source Testing */
 if (import.meta.vitest) {
-  const { test, expect } = import.meta.vitest;
-  const path = await import('path');
-  const { isError } = await import('../util/error/error');
+  const { describe, test, expect } = import.meta.vitest;
 
-  // 一時使用フォルダを初期化
-  const workPath = new Path(__dirname).child(
-    'work',
-    path.basename(__filename, '.ts')
-  );
-  workPath.mkdir();
+  describe('logger', async () => {
+    const path = await import('path');
+    const { isError } = await import('../util/error/error');
 
-  // ログオブジェクト
-  const { logger, archive } = getRootLogger(workPath);
-
-  const logpath = workPath.child(LATEST);
-
-  const readLastLogLine = async () => {
-    const logTxt = await logpath.readText();
-    if (isError(logTxt)) return logTxt;
-    const lines = logTxt.trim().split(/\r?\n|\r/);
-    return lines[lines.length - 1];
-  };
-
-  test('base logger test', async () => {
-    const log = logger.test.base({});
-    log.info('test message');
-    expect(await readLastLogLine()).toBe(
-      '{"level":"INFO","state":"info","category":"test.base","args":{},"data":["test message"]}'
+    // 一時使用フォルダを初期化
+    const workPath = new Path(__dirname).child(
+      'work',
+      path.basename(__filename, '.ts')
     );
-  });
+    workPath.mkdir();
 
-  test('archive logs', async () => {
-    await archive();
-    const prefix = dayjs().format('YYYY-MM-DD-HH');
-    const targetArchivePath = workPath.child(`${prefix}-0.log.gz`);
-    expect(targetArchivePath.exists()).toBe(true);
-  });
+    // ログオブジェクト
+    const { logger, archive } = getRootLogger(workPath);
 
-  // アーカイブデータが残っているとarchive logsのテストが意味をなさないため，毎回削除する
-  test('remove work folder', async () => {
-    await workPath.parent().remove();
-    expect(workPath.exists()).toBe(false);
+    const logpath = workPath.child(LATEST);
+
+    const readLastLogLine = async () => {
+      const logTxt = await logpath.readText();
+      if (isError(logTxt)) return logTxt;
+      const lines = logTxt.trim().split(/\r?\n|\r/);
+      return lines[lines.length - 1];
+    };
+
+    test('base logger test', async () => {
+      const log = logger.test.base({});
+      log.info('test message');
+      expect(await readLastLogLine()).toBe(
+        '{"level":"INFO","state":"info","category":"test.base","args":{},"data":["test message"]}'
+      );
+    });
+
+    test('archive logs', async () => {
+      await archive();
+      const prefix = dayjs().format('YYYY-MM-DD-HH');
+      const targetArchivePath = workPath.child(`${prefix}-0.log.gz`);
+      expect(targetArchivePath.exists()).toBe(true);
+    });
+
+    // アーカイブデータが残っているとarchive logsのテストが意味をなさないため，毎回削除する
+    test('remove work folder', async () => {
+      await workPath.parent().remove();
+      expect(workPath.exists()).toBe(false);
+    });
   });
 }

--- a/src-electron/common/logger.ts
+++ b/src-electron/common/logger.ts
@@ -2,6 +2,7 @@ import dayjs, { Dayjs } from 'dayjs';
 import log4js from 'log4js';
 import { c } from 'tar';
 import { Path } from '../util/binary/path';
+import { isError } from '../util/error/error';
 
 const LATEST = 'latest.log';
 const ARCHIVE_EXT = '.log.gz';
@@ -88,7 +89,9 @@ async function archiveLog(logDir: Path) {
 
   // 一週間前のログファイルを削除
   const thresholdDate = dayjs().subtract(7, 'd');
-  for (const path of await logDir.iter()) {
+  const paths = await logDir.iter();
+  if (isError(paths)) return;
+  for (const path of paths) {
     if (!path.path.endsWith(ARCHIVE_EXT)) continue;
     const updateDate = await path.lastUpdateTime();
     if (updateDate.isBefore(thresholdDate)) await path.remove();

--- a/src-electron/source/additionalContents/datapack/datapack.ts
+++ b/src-electron/source/additionalContents/datapack/datapack.ts
@@ -21,8 +21,10 @@ const MCMETA_FILE = 'pack.mcmeta';
 
 async function loader(path: Path): Promise<Failable<DatapackData>> {
   let mcmetaData: Failable<BytesData>;
+  const isPathDir = await path.isDirectory();
+  if (isError(isPathDir)) return isPathDir;
 
-  if (await path.isDirectory()) {
+  if (isPathDir) {
     // ディレクトリの場合
     const metaPath = path.child(MCMETA_FILE);
     // pack.mcmetaが存在しない場合エラー

--- a/src-electron/source/additionalContents/plugin/plugin.ts
+++ b/src-electron/source/additionalContents/plugin/plugin.ts
@@ -2,6 +2,7 @@ import { PluginData } from 'app/src-electron/schema/filedata';
 import { PLUGIN_CACHE_PATH } from 'app/src-electron/source/const';
 import { Path } from 'app/src-electron/util/binary/path';
 import { errorMessage } from 'app/src-electron/util/error/construct';
+import { isError } from 'app/src-electron/util/error/error';
 import { Failable } from 'app/src-electron/util/error/failable';
 import { ServerAdditionalFiles } from '../base';
 
@@ -14,7 +15,10 @@ async function loader(
   path: Path,
   force: boolean
 ): Promise<Failable<PluginData | undefined>> {
-  if (await path.isDirectory()) {
+  const isPathDir = await path.isDirectory();
+  if (isError(isPathDir)) return isPathDir;
+
+  if (isPathDir) {
     if (force) {
       return errorMessage.data.path.invalidContent.invalidPlugin({
         path: path.path,

--- a/src-electron/source/launcher/localSave.ts
+++ b/src-electron/source/launcher/localSave.ts
@@ -33,6 +33,9 @@ export async function getAllLocalSaveData(): Promise<
 export async function getLocalSaveData(
   container: Path
 ): Promise<WithError<CustomMapData[]>> {
-  const result = await asyncMap(await container.iter(), loadCustomMap);
+  const containers = await container.iter();
+  if (isError(containers)) return withError([], [containers]);
+
+  const result = await asyncMap(containers, loadCustomMap);
   return withError(result.filter(isValid), result.filter(isError));
 }

--- a/src-electron/source/player/cache.ts
+++ b/src-electron/source/player/cache.ts
@@ -75,6 +75,11 @@ export async function pushPlayerCache(player: Player) {
   await setPlayerCache(cache);
 }
 
+/**
+ * プレイヤー情報をキャッシュに登録する
+ * 
+ * キャッシュへの登録処理でエラーが出てもユーザーには問題がないため握りつぶす
+ */
 async function setPlayerCache(cache: PlayerCache) {
   await PLAYER_CACHE_PATH.writeJson(cache);
 }

--- a/src-electron/source/player/cache.ts
+++ b/src-electron/source/player/cache.ts
@@ -77,7 +77,7 @@ export async function pushPlayerCache(player: Player) {
 
 /**
  * プレイヤー情報をキャッシュに登録する
- * 
+ *
  * キャッシュへの登録処理でエラーが出てもユーザーには問題がないため握りつぶす
  */
 async function setPlayerCache(cache: PlayerCache) {

--- a/src-electron/source/remote/github/sync.ts
+++ b/src-electron/source/remote/github/sync.ts
@@ -1,5 +1,5 @@
 import { simpleGit, SimpleGitProgressEvent } from 'simple-git';
-import { GithubRemoteFolder, Remote } from 'src-electron/schema/remote';
+import { Remote } from 'src-electron/schema/remote';
 import { GroupProgressor } from 'app/src-electron/common/progress';
 import { Failable } from 'app/src-electron/schema/error';
 import { Path } from 'app/src-electron/util/binary/path';
@@ -34,13 +34,13 @@ const DEFAULT_REMOTE_NAME = 'serverstarter';
 
 // TODO: ログの追加
 
-function getRemoteUrl(remote: Remote<GithubRemoteFolder>) {
+function getRemoteUrl(remote: Remote) {
   // githubでないホストを使用していた場合エラー
   return `https://github.com/${remote.folder.owner}/${remote.folder.repo}`;
 }
 
 // SimpleGitインスタンスを取得
-async function setupGit(local: Path, remote: Remote<GithubRemoteFolder>) {
+async function setupGit(local: Path, remote: Remote) {
   // プログレス周りの処理
   const [set, invoke] = logger();
 
@@ -101,7 +101,7 @@ async function setupGit(local: Path, remote: Remote<GithubRemoteFolder>) {
 
 export async function pullWorld(
   local: Path,
-  remote: Remote<GithubRemoteFolder>,
+  remote: Remote,
   progress?: GroupProgressor
 ): Promise<Failable<undefined>> {
   progress?.title({ key: 'server.pull.title' });
@@ -136,7 +136,7 @@ export async function pullWorld(
 
 export async function pushWorld(
   local: Path,
-  remote: Remote<GithubRemoteFolder>,
+  remote: Remote,
   progress?: GroupProgressor
 ): Promise<Failable<undefined>> {
   progress?.title({ key: 'server.push.title' });
@@ -182,7 +182,7 @@ export async function pushWorld(
 }
 
 export async function deleteWorld(
-  remote: Remote<GithubRemoteFolder>
+  remote: Remote
 ): Promise<Failable<undefined>> {
   // 一時フォルダ内で実行
   await gitTempPath.mkdir(true);
@@ -204,7 +204,7 @@ export async function deleteWorld(
   // リモートのブランチを削除
   const push = await safeExecAsync(() => git.push(url, `:${remote.name}`));
 
-  // 一時フォルダを削除
+  // 一時フォルダを削除（削除失敗がユーザーに影響しないため無視）
   await gitTempPath.remove();
 
   // pushに失敗した場合

--- a/src-electron/source/runtime/manifest.ts
+++ b/src-electron/source/runtime/manifest.ts
@@ -29,14 +29,13 @@ export async function getVersionMainfest(): Promise<Failable<ManifestJson>> {
   // URLからデータを取得 (内容が変わっている可能性があるのでsha1チェックは行わない)
   const response = await BytesData.fromURL(MANIFEST_URL);
 
-  if (isValid(response)) {
-    // 成功した場合ローカルに保存
-    versionConfig.set('version_manifest_v2_sha1', await response.hash('sha1'));
-    versionManifestPath.write(response);
-  } else {
-    // 失敗した場合ローカルから取得
-    return getLocalVersionMainfest();
-  }
+  // 失敗した場合ローカルから取得
+  if (isError(response)) return getLocalVersionMainfest();
+
+  // 成功した場合ローカルに保存
+  versionConfig.set('version_manifest_v2_sha1', await response.hash('sha1'));
+  const failableWrite = versionManifestPath.write(response);
+  if (isError(failableWrite)) return getLocalVersionMainfest();
 
   const manifest = await response.json<ManifestJson>();
   return manifest;

--- a/src-electron/source/server/setup/eula.ts
+++ b/src-electron/source/server/setup/eula.ts
@@ -78,7 +78,8 @@ export async function checkEula(
     key: 'server.eula.saving',
   });
   // eulaの内容を書き込む
-  await eulaPath.writeText(txt);
+  const writeEula = await eulaPath.writeText(txt);
+  if (isError(writeEula)) return writeEula;
   saveSub.delete();
 
   return agree;
@@ -117,13 +118,12 @@ async function generateEula(
   programArgunets: string[],
   serverCwdPath: Path,
   version: Version
-): Promise<Failable<undefined>> {
+): Promise<Failable<void>> {
   const eulaPath = serverCwdPath.child('eula.txt');
 
   // mohistmcはeula.txtを生成して終了しないためこちらで生成してしまう
   if (version.type === 'mohistmc') {
-    await eulaPath.writeText('eula=false');
-    return;
+    return await eulaPath.writeText('eula=false');
   }
 
   // サーバーを仮起動

--- a/src-electron/source/server/setup/eula.ts
+++ b/src-electron/source/server/setup/eula.ts
@@ -151,7 +151,7 @@ async function generateEula(
   if (isError(result)) return result;
 
   if (!eulaPath.exists()) {
-    return errorMessage.data.path.creationFiled({
+    return errorMessage.data.path.creationFailed({
       type: 'file',
       path: eulaPath.path,
     });

--- a/src-electron/source/server/setup/log4j.ts
+++ b/src-electron/source/server/setup/log4j.ts
@@ -513,7 +513,7 @@ async function download_xml_12_16(serverPath: Path) {
       'https://launcher.mojang.com/v1/objects/02937d122c86ce73319ef9975b58896fc1b491d1/log4j2_112-116.xml'
     );
     if (isError(data)) return data;
-    await xml.write(data);
+    return await xml.write(data);
   }
 }
 
@@ -525,7 +525,7 @@ async function download_xml_7_11(serverPath: Path) {
       'https://launcher.mojang.com/v1/objects/dd2b723346a8dcd48e7f4d245f6bf09e98db9696/log4j2_17-111.xml'
     );
     if (isError(data)) return data;
-    await xml.write(data);
+    return await xml.write(data);
   }
 }
 
@@ -537,6 +537,9 @@ export async function getLog4jArg(
 ): Promise<Failable<string | null>> {
   // log4jの脆弱性に対応
   // https://www.minecraft.net/ja-jp/article/important-message--security-vulnerability-java-edition-jp
+
+  // unknown version
+  if (version.type === 'unknown') return null;
 
   // 1.17-1.18
   if (version.id in ver_17_18) {

--- a/src-electron/source/version/base.ts
+++ b/src-electron/source/version/base.ts
@@ -83,7 +83,8 @@ export const genGetAllVersions = <V extends Version>(
     }
 
     // 結果をローカルに保存
-    await jsonpath.write(data);
+    const failableWrite = await jsonpath.write(data);
+    if (isError(failableWrite)) return failableWrite;
     versionConfig.set(configkey, await data.hash('sha1'));
 
     logger.success('load from remote');

--- a/src-electron/source/version/spigot.ts
+++ b/src-electron/source/version/spigot.ts
@@ -162,7 +162,7 @@ const SPIGOT_BUILDTOOL_URL =
 /** ビルドツールのダウンロード */
 async function readySpigotBuildTool(
   buildDir: Path
-): Promise<Failable<undefined>> {
+): Promise<Failable<void>> {
   // ビルドツールをダウンロード
   const buildtool = await BytesData.fromURL(SPIGOT_BUILDTOOL_URL);
 
@@ -174,7 +174,7 @@ async function readySpigotBuildTool(
   // ハッシュ値をコンフィグに保存
   versionConfig.set('spigot_buildtool_sha1', await buildtool.hash('sha1'));
 
-  await buildToolPath.write(buildtool);
+  return buildToolPath.write(buildtool);
 }
 
 type SpigotVersionData = {
@@ -280,7 +280,8 @@ async function buildSpigotVersion(
     });
   }
 
-  await jarPath.rename(targetpath);
+  const isSuccessRename = await jarPath.rename(targetpath);
+  if (isError(isSuccessRename)) return isSuccessRename;
 
   m?.delete();
 }

--- a/src-electron/source/version/spigot.ts
+++ b/src-electron/source/version/spigot.ts
@@ -100,7 +100,7 @@ async function readyCachedSpigotVersion(
   const buildTool = await readySpigotBuildTool(buildDir);
   b?.delete();
   if (isError(buildTool)) {
-    // 一時フォルダの削除
+    // 一時フォルダの削除（削除失敗がユーザーに影響しないため無視）
     await buildDir.remove();
     return buildTool;
   }
@@ -113,7 +113,7 @@ async function readyCachedSpigotVersion(
     component,
     progress
   );
-  // 一時フォルダの削除
+  // 一時フォルダの削除（削除失敗がユーザーに影響しないため無視）
   await buildDir.remove();
   if (isError(buildResult)) return buildResult;
 

--- a/src-electron/source/version/spigot.ts
+++ b/src-electron/source/version/spigot.ts
@@ -160,9 +160,7 @@ const SPIGOT_BUILDTOOL_URL =
   'https://hub.spigotmc.org/jenkins/job/BuildTools/lastSuccessfulBuild/artifact/target/BuildTools.jar';
 
 /** ビルドツールのダウンロード */
-async function readySpigotBuildTool(
-  buildDir: Path
-): Promise<Failable<void>> {
+async function readySpigotBuildTool(buildDir: Path): Promise<Failable<void>> {
   // ビルドツールをダウンロード
   const buildtool = await BytesData.fromURL(SPIGOT_BUILDTOOL_URL);
 

--- a/src-electron/source/version/vanilla.ts
+++ b/src-electron/source/version/vanilla.ts
@@ -75,11 +75,12 @@ export const vanillaVersionLoader: VersionLoader<VanillaVersion> = {
     const s = progress?.subtitle({
       key: 'server.readyVersion.vanilla.saving',
     });
-    await jarpath.write(serverData);
+    const failableWriteJar = await jarpath.write(serverData);
+    if (isError(failableWriteJar)) return failableWriteJar;
     s?.delete();
 
     return {
-      programArguments: ['-jar', jarpath.absolute().strQuoted()],
+      programArguments: ['-jar', jarpath.absolute().quotedPath],
       component: json.javaVersion?.component ?? 'jre-legacy',
     };
   },

--- a/src-electron/source/world/customMap.ts
+++ b/src-electron/source/world/customMap.ts
@@ -237,7 +237,7 @@ async function importCustomMapZip(
   if (isError(datFile)) return datFile;
   const innerPath = datFile[0];
 
-  // 一時ディレクトリを削除
+  // 一時ディレクトリを削除（削除失敗がユーザーに影響しないため無視）
   await unzipPath.remove();
 
   // zipを一時パスに展開
@@ -257,7 +257,8 @@ async function importCustomMapZip(
   // ワールドデータ内部にserver.propertiesが存在する場合
 
   // ワールドデータを移動
-  await unzipPath.child(innerPath).parent().moveTo(worldPath);
+  const moveWorld = await unzipPath.child(innerPath).parent().moveTo(worldPath);
+  if (isError(moveWorld)) return moveWorld;
 
   // ワールド以外のデータ(readmeとか?)も可能であれば移動
   if (unzipPath.exists()) {
@@ -267,7 +268,7 @@ async function importCustomMapZip(
     }
   }
 
-  // 一時ディレクトリを削除
+  // 一時ディレクトリを削除（削除失敗がユーザーに影響しないため無視）
   await unzipPath.remove();
 
   return props;

--- a/src-electron/source/world/customMap.ts
+++ b/src-electron/source/world/customMap.ts
@@ -199,7 +199,7 @@ async function importCustomMapDir(
 async function cacheLocalMods(sourcePath: Path): Promise<void> {
   const paths = await sourcePath.parent(2).child('mods').iter();
   if (isError(paths)) return;
-  
+
   const load = async (path: Path) => await modFiles.loadNew(path);
   const mods = (await asyncMap(paths, load)).filter(isValid);
   await asyncMap(mods, async (data) => await modFiles.appendCache(data));
@@ -209,7 +209,7 @@ async function cacheLocalMods(sourcePath: Path): Promise<void> {
 async function cacheLocalPlugins(sourcePath: Path): Promise<void> {
   const paths = await sourcePath.parent(2).child('plugins').iter();
   if (isError(paths)) return;
-  
+
   const load = async (path: Path) => await pluginFiles.loadNew(path);
   const plugins = (await asyncMap(paths, load)).filter(isValid);
   await asyncMap(plugins, async (data) => await pluginFiles.appendCache(data));
@@ -219,7 +219,7 @@ async function cacheLocalPlugins(sourcePath: Path): Promise<void> {
 async function cacheLocalDatapacks(sourcePath: Path): Promise<void> {
   const paths = await sourcePath.child('datapacks').iter();
   if (isError(paths)) return;
-  
+
   const load = async (path: Path) => await datapackFiles.loadNew(path);
   const datapacks = (await asyncMap(paths, load)).filter(isValid);
   await asyncMap(datapacks, async (data) => datapackFiles.appendCache(data));

--- a/src-electron/source/world/customMap.ts
+++ b/src-electron/source/world/customMap.ts
@@ -58,6 +58,7 @@ export async function loadCustomMap(
   path: Path
 ): Promise<Failable<CustomMapData>> {
   const isDirectory = await path.isDirectory();
+  if (isError(isDirectory)) return isDirectory;
 
   /** level.dat の内容 */
   let dat: Failable<BytesData>;
@@ -197,6 +198,8 @@ async function importCustomMapDir(
 /** ローカルで使われていたであろうMOD一覧をキャッシュにコピー */
 async function cacheLocalMods(sourcePath: Path): Promise<void> {
   const paths = await sourcePath.parent(2).child('mods').iter();
+  if (isError(paths)) return;
+  
   const load = async (path: Path) => await modFiles.loadNew(path);
   const mods = (await asyncMap(paths, load)).filter(isValid);
   await asyncMap(mods, async (data) => await modFiles.appendCache(data));
@@ -205,6 +208,8 @@ async function cacheLocalMods(sourcePath: Path): Promise<void> {
 /** ローカルで使われていたであろうPlugin一覧をキャッシュにコピー */
 async function cacheLocalPlugins(sourcePath: Path): Promise<void> {
   const paths = await sourcePath.parent(2).child('plugins').iter();
+  if (isError(paths)) return;
+  
   const load = async (path: Path) => await pluginFiles.loadNew(path);
   const plugins = (await asyncMap(paths, load)).filter(isValid);
   await asyncMap(plugins, async (data) => await pluginFiles.appendCache(data));
@@ -213,6 +218,8 @@ async function cacheLocalPlugins(sourcePath: Path): Promise<void> {
 /** ローカルで使われていたであろうDatapack一覧をキャッシュにコピー */
 async function cacheLocalDatapacks(sourcePath: Path): Promise<void> {
   const paths = await sourcePath.child('datapacks').iter();
+  if (isError(paths)) return;
+  
   const load = async (path: Path) => await datapackFiles.loadNew(path);
   const datapacks = (await asyncMap(paths, load)).filter(isValid);
   await asyncMap(datapacks, async (data) => datapackFiles.appendCache(data));

--- a/src-electron/source/world/files/bannedIps.ts
+++ b/src-electron/source/world/files/bannedIps.ts
@@ -28,7 +28,7 @@ export const bannedIpsHandler: ServerSettingFile<BannedIps> = {
   save(cwdPath, value) {
     return cwdPath.child(FILENAME).writeText(JSON.stringify(value));
   },
-  remove(cwdPath) {
-    return cwdPath.child(FILENAME).remove();
+  path(cwdPath) {
+    return cwdPath.child(FILENAME);
   },
 };

--- a/src-electron/source/world/files/bannedPlayers.ts
+++ b/src-electron/source/world/files/bannedPlayers.ts
@@ -30,7 +30,7 @@ export const bannedPlayersHandler: ServerSettingFile<BannedPlayers> = {
   save(cwdPath, value) {
     return cwdPath.child(FILENAME).writeText(JSON.stringify(value));
   },
-  remove(cwdPath) {
-    return cwdPath.child(FILENAME).remove();
+  path(cwdPath) {
+    return cwdPath.child(FILENAME);
   },
 };

--- a/src-electron/source/world/files/icon.ts
+++ b/src-electron/source/world/files/icon.ts
@@ -29,7 +29,7 @@ export const serverIconFile: ServerSettingFile<ImageURI | undefined> = {
 
     const iconpath = serverIconFile.path(cwdPath);
 
-    await iconpath.write(icondata);
+    return iconpath.write(icondata);
   },
   path(cwdPath) {
     return cwdPath.child(ICON_PATH);

--- a/src-electron/source/world/files/json.ts
+++ b/src-electron/source/world/files/json.ts
@@ -81,7 +81,7 @@ export const serverJsonFile: ServerSettingFile<WorldSettings> = {
   },
   async save(cwdPath, value) {
     const jsonPath = cwdPath.child(WORLD_SETTINGS_PATH);
-    await jsonPath.writeJson(value);
+    return await jsonPath.writeJson(value);
   },
   path(cwdPath) {
     return cwdPath.child(WORLD_SETTINGS_PATH);

--- a/src-electron/source/world/files/properties.ts
+++ b/src-electron/source/world/files/properties.ts
@@ -47,8 +47,7 @@ export const serverPropertiesFile: ServerSettingFile<ServerProperties> = {
   },
   async save(cwdPath, value) {
     const filePath = cwdPath.child(SERVER_PROPERTIES_PATH);
-
-    await filePath.writeText(stringify(value));
+    return await filePath.writeText(stringify(value));
   },
   path(cwdPath) {
     return cwdPath.child(SERVER_PROPERTIES_PATH);

--- a/src-electron/source/world/handler.ts
+++ b/src-electron/source/world/handler.ts
@@ -675,7 +675,8 @@ export class WorldHandler {
     if (isError(tar)) return withError(tar);
 
     // tarファイルを保存
-    await backupPath.write(tar);
+    const failableWrite = await backupPath.write(tar);
+    if (isError(failableWrite)) return withError(failableWrite);
 
     // バックアップデータを返却
     return withError(await parseBackUpPath(backupPath));
@@ -882,7 +883,9 @@ export class WorldHandler {
 
     // 実行時のサーバープロパティ(ポートだけ違う)
     const execServerProperties: ServerProperties = {
-      ...(isError(beforeWorld.properties) ? {} : beforeWorld.properties),
+      ...(isError(beforeWorld.properties)
+        ? sysSettings.world.properties
+        : beforeWorld.properties),
     };
     const beforeServerPort = execServerProperties['server-port'];
     const beforeQueryport = execServerProperties['query.port'];

--- a/src-electron/source/world/local.ts
+++ b/src-electron/source/world/local.ts
@@ -315,23 +315,23 @@ export async function formatWorldDirectory(
   progress?.title({ key: 'server.run.before.convertDirectory' });
   switch (true) {
     case current === 'vanilla' && next === 'plugin':
-      await asyncMap(
+      const moveV2P = await asyncMap(
         [
           { from: vanillaNether, to: pluginNether },
           { from: vanillaEnd, to: pluginEnd },
         ],
         ({ from, to }) => from.moveTo(to)
       );
-      return withError(undefined);
+      return withError(undefined, moveV2P.filter(isError));
     case current === 'plugin' && next === 'vanilla':
-      await asyncMap(
+      const moveP2V = await asyncMap(
         [
           { from: pluginNether, to: vanillaNether },
           { from: pluginEnd, to: vanillaEnd },
         ],
         ({ from, to }) => from.moveTo(to)
       );
-      return withError(undefined);
+      return withError(undefined, moveP2V.filter(isError));
     default:
       throw new Error(
         `not implemanted worldDirectoryType conversion: ${current} to ${next}`

--- a/src-electron/source/world/local.ts
+++ b/src-electron/source/world/local.ts
@@ -171,10 +171,11 @@ export async function saveLocalFiles(
   // TODO: メソッドを分割すべき
   if (world.custom_map) {
     // ファイル削除待機
-    await asyncForEach(
+    const removeRes = await asyncMap(
       [PLUGIN_NETHER_LEVEL_NAME, PLUGIN_THE_END_LEVEL_NAME],
       (path) => savePath.child(path).remove()
     );
+    errors.push(...removeRes.filter(isError));
 
     // 導入待機
     const importResult = await importCustomMap(
@@ -219,7 +220,7 @@ export async function saveLocalFiles(
     if (isError(pull)) errors.push(pull);
   }
 
-  const promisses: Promise<any>[] = [
+  const promisses: Promise<Failable<any>>[] = [
     serverJsonFile.save(savePath, worldSettings),
     serverIconFile.save(savePath, world.avater_path),
   ];
@@ -247,7 +248,8 @@ export async function saveLocalFiles(
     promisses.push(serverPropertiesFile.save(savePath, world.properties));
   }
 
-  await Promise.all(promisses);
+  const promissesRes = await Promise.all(promisses);
+  errors.push(...promissesRes.filter(isError));
 
   // ローカルのデータを再読み込みして返却
   return constructResult();

--- a/src-electron/source/world/loghandler.ts
+++ b/src-electron/source/world/loghandler.ts
@@ -24,7 +24,7 @@ export class WorldLogHandler {
 
   /**
    * 現状のlatest.logをアーカイブ化する(存在する場合)
-   * 
+   *
    * Failの可能性があるが，latest.logのアーカイブ成否はユーザーの実行に問題にならないため通知しない
    */
   async archive() {
@@ -50,9 +50,9 @@ export class WorldLogHandler {
     return path;
   }
 
-  /** 
+  /**
    * 一時記録用のログファイルに追記
-   * 
+   *
    * ログへの書き込みに問題が生じてもユーザーには問題がないため，appendTextのエラーは通知しない
    */
   async append(content: string) {

--- a/src-electron/source/world/loghandler.ts
+++ b/src-electron/source/world/loghandler.ts
@@ -24,6 +24,8 @@ export class WorldLogHandler {
 
   /**
    * 現状のlatest.logをアーカイブ化する(存在する場合)
+   * 
+   * Failの可能性があるが，latest.logのアーカイブ成否はユーザーの実行に問題にならないため通知しない
    */
   async archive() {
     const latestPath = this.LatestLogPath;

--- a/src-electron/source/world/loghandler.ts
+++ b/src-electron/source/world/loghandler.ts
@@ -1,4 +1,4 @@
-import dayjs from 'dayjs';
+import dayjs, { Dayjs } from 'dayjs';
 import { Failable } from 'app/src-electron/schema/error';
 import { AwaitOnce } from 'app/src-electron/util/awaitOnce';
 import { gzip } from 'app/src-electron/util/binary/archive/gz';
@@ -40,8 +40,8 @@ export class WorldLogHandler {
     return this.logsPath.child('latest.log');
   }
 
-  private getArchivePath(date: Date) {
-    const base = dayjs(date).format('YYYY-MM-DD');
+  private getArchivePath(date: Dayjs) {
+    const base = date.format('YYYY-MM-DD');
     let i = 1;
     let path = this.logsPath.child(`${base}-${i}.log.gz`);
     while (path.exists()) path = this.logsPath.child(`${base}-${++i}.log.gz`);

--- a/src-electron/source/world/loghandler.ts
+++ b/src-electron/source/world/loghandler.ts
@@ -50,7 +50,11 @@ export class WorldLogHandler {
     return path;
   }
 
-  /** 一時記録用のログファイルに追記 */
+  /** 
+   * 一時記録用のログファイルに追記
+   * 
+   * ログへの書き込みに問題が生じてもユーザーには問題がないため，appendTextのエラーは通知しない
+   */
   async append(content: string) {
     const tmp = await this.tempPath.get();
     tmp.appendText(content);

--- a/src-electron/source/world/world.ts
+++ b/src-electron/source/world/world.ts
@@ -28,6 +28,8 @@ export async function getWorldAbbrs(
 ): Promise<WithError<WorldAbbr[]>> {
   const dir = worldContainerToPath(worldContainer);
   const subdir = await dir.iter();
+  if (isError(subdir)) return withError([], [subdir]);
+
   const results = await asyncMap(subdir, (x) =>
     getWorldAbbr(x, worldContainer)
   );

--- a/src-electron/updater/installer/windows.ts
+++ b/src-electron/updater/installer/windows.ts
@@ -2,12 +2,15 @@ import { spawn } from 'child_process';
 import { app } from 'electron';
 import { mainPath } from 'app/src-electron/source/const';
 import { getSystemSettings } from 'app/src-electron/source/stores/system';
-import { BytesData } from 'app/src-electron/util/binary/bytesData';
 import { isError } from 'app/src-electron/util/error/error';
 import { getBytesFile } from 'app/src-electron/util/github/rest';
 import { updateMessage } from './message';
 
-/** windowsの最新版をダウンロードしてインストールして再起動 */
+/** 
+ * windowsの最新版をダウンロードしてインストールして再起動
+ * 
+ * アップデートに失敗してもエラーで処理を止める必要がないため握りつぶす
+ */
 export const installWindows = async (
   msiurl: string,
   pat: string | undefined
@@ -15,21 +18,23 @@ export const installWindows = async (
   const dest = mainPath.child('updater.msi');
 
   const data = await getBytesFile(msiurl, pat);
-
   if (isError(data)) return;
-  await data.write(dest.str(), true);
+
+  const writeUpdater = await data.write(dest.path, true);
+  if (isError(writeUpdater)) return;
 
   const sys = await getSystemSettings();
 
   const bat = mainPath.child('updater.bat');
-  await bat.writeText(`@echo off
+  const writeBat = await bat.writeText(`@echo off
 echo ${updateMessage[sys.user.language].main}
 msiexec /i updater.msi /qb
 start "" "${app.getPath('exe')}"
 exit`);
+    if (isError(writeBat)) return;
 
   const sub = spawn('start', ['/min', '""', 'updater.bat'], {
-    cwd: mainPath.str(),
+    cwd: mainPath.path,
     env: process.env,
     shell: true,
     detached: true,

--- a/src-electron/updater/installer/windows.ts
+++ b/src-electron/updater/installer/windows.ts
@@ -6,9 +6,9 @@ import { isError } from 'app/src-electron/util/error/error';
 import { getBytesFile } from 'app/src-electron/util/github/rest';
 import { updateMessage } from './message';
 
-/** 
+/**
  * windowsの最新版をダウンロードしてインストールして再起動
- * 
+ *
  * アップデートに失敗してもエラーで処理を止める必要がないため握りつぶす
  */
 export const installWindows = async (
@@ -31,7 +31,7 @@ echo ${updateMessage[sys.user.language].main}
 msiexec /i updater.msi /qb
 start "" "${app.getPath('exe')}"
 exit`);
-    if (isError(writeBat)) return;
+  if (isError(writeBat)) return;
 
   const sub = spawn('start', ['/min', '""', 'updater.bat'], {
     cwd: mainPath.path,

--- a/src-electron/util/binary/archive/tar.ts
+++ b/src-electron/util/binary/archive/tar.ts
@@ -1,7 +1,7 @@
 import { Writable } from 'stream';
 import { c, x } from 'tar';
 import { Failable } from '../../../schema/error';
-import { fromRuntimeError } from '../../error/error';
+import { fromRuntimeError, isError } from '../../error/error';
 import { safeExecAsync } from '../../error/failable';
 import { BytesData } from '../bytesData';
 import { Path } from '../path';
@@ -19,8 +19,10 @@ export async function createTar(
   });
 
   await new Promise<Failable<undefined>>(async (resolve) => {
-    const path = directoryPath.str();
+    const path = directoryPath.path;
     const inner = await directoryPath.iter();
+    if (isError(inner)) return resolve(inner);
+
     c(
       {
         gzip,
@@ -43,8 +45,8 @@ export async function decompressTar(
 ): Promise<Failable<void>> {
   return await safeExecAsync(() =>
     x({
-      file: tarPath.str(),
-      cwd: targetPath.str(),
+      file: tarPath.path,
+      cwd: targetPath.path,
     })
   );
 }

--- a/src-electron/util/binary/archive/zipFile.ts
+++ b/src-electron/util/binary/archive/zipFile.ts
@@ -99,7 +99,7 @@ export class ZipFile {
   }
 
   /** zipを展開 */
-  async extract(path: Path) {
+  async extract(path: Path): Promise<Failable<void>> {
     const files = await this.handler.files;
     if (isError(files)) return files;
     const ents = toEntries(files);

--- a/src-electron/util/binary/path.ts
+++ b/src-electron/util/binary/path.ts
@@ -107,7 +107,6 @@ export class Path {
     });
   }
 
-  // TODO: エラーの戻り値を考慮して呼び出し元を修正
   isDirectory = exclusive(this._isDirectory);
   private async _isDirectory(): Promise<Failable<boolean>> {
     const stat = await this._stat();
@@ -128,7 +127,6 @@ export class Path {
     if (isError(isDir)) return isDir;
 
     return fs.rename(this._path, newpath.absolute().path).catch(async () => {
-      // TODO: エラーの戻り値を考慮して呼び出し元を修正
       return errorMessage.data.path.renameFailed({
         type: isDir ? 'directory' : 'file',
         path: this.path,
@@ -182,7 +180,6 @@ export class Path {
 
   write = exclusive(this._write);
   private async _write(content: BytesData) {
-    // TODO: エラーの戻り値を考慮して呼び出し元を修正
     await this.parent().mkdir(true);
     return content.write(this._path);
   }

--- a/src-electron/util/binary/path.ts
+++ b/src-electron/util/binary/path.ts
@@ -4,9 +4,13 @@
 //
 import * as fs from 'fs-extra';
 import * as path from 'path';
+import { errorMessage } from '../error/construct';
 import { isError } from '../error/error';
 import { Failable } from '../error/failable';
+import { InfinitMap } from '../helper/infinitMap';
 import { asyncForEach } from '../obj/objmap';
+import { sleep } from '../promise/sleep';
+import { PromiseSpooler } from '../promise/spool';
 import type { BytesData } from './bytesData';
 
 function replaceSep(pathstr: string) {
@@ -19,167 +23,264 @@ async function loadBytesData() {
 }
 
 export class Path {
-  path: string;
-  constructor(value?: string) {
+  private _path: string;
+  constructor(value?: string | Path) {
     if (value === undefined) {
-      this.path = '';
+      this._path = '';
+    } else if (typeof value === 'string') {
+      this._path = path.normalize(replaceSep(value));
     } else {
-      this.path = path.normalize(replaceSep(value));
+      this._path = value._path;
     }
   }
 
-  child(child: string) {
-    if (this.path !== '') {
-      return new Path(path.join(this.path, child));
+  isLocked(): boolean {
+    return spoolers.get(this.absolute().path).hasSpooled();
+  }
+
+  child(...paths: string[]) {
+    if (this._path !== '') {
+      return new Path(path.join(this._path, ...paths));
     }
-    return new Path(child);
+    return new Path(path.join(...paths));
   }
 
   parent(times = 1) {
-    if (this.path) {
-      return new Path(path.join(this.path, ...new Array(times).fill('..')));
+    if (this._path) {
+      return new Path(path.join(this._path, ...new Array(times).fill('..')));
     }
     return new Path(path.join(...Array(times).fill('..')));
   }
 
   absolute() {
-    return new Path(path.resolve(this.path));
+    return new Path(path.resolve(this._path));
   }
 
   /** このpathを起点にしたtargetの相対パスを返す */
   relativeto(target: Path) {
-    return new Path(path.relative(this.path, target.path));
+    return new Path(path.relative(this._path, target._path));
   }
 
-  str() {
-    return this.path;
+  /** パスを文字列化する */
+  get path() {
+    return this._path;
   }
 
   /** "で囲まれたパス文字列を返す */
+  get quotedPath() {
+    return `"${this._path.replace('\\', '\\\\').replace('"', '\\"')}"`;
+  }
+
+  /** @deprecated TODO: .pathへ修正*/
+  str() {
+    return this._path;
+  }
+
+  /** @deprecated TODO: .quotedPathへ修正 */
   strQuoted() {
-    return `"${this.path.replace('\\', '\\\\').replace('"', '\\"')}"`;
+    return `"${this._path.replace('\\', '\\\\').replace('"', '\\"')}"`;
   }
 
   /** ディレクトリ階層を除いたファイル名を返す ".../../file.txt" -> "file.txt" */
   basename() {
-    return path.basename(this.path);
+    return path.basename(this._path);
   }
 
   /** ディレクトリ階層を除いたファイル名(拡張子なし)を返す ".../../file.txt" -> "file" */
   stemname() {
-    return path.basename(this.path, this.extname());
+    return path.basename(this._path, this.extname());
   }
 
   /** 拡張子を返す ".../../file.txt" -> ".txt" */
   extname() {
-    return path.extname(this.path);
+    return path.extname(this._path);
   }
 
   exists() {
-    return fs.existsSync(this.path);
+    return fs.existsSync(this._path);
   }
 
-  async isDirectory() {
-    return (await fs.stat(this.absolute().str())).isDirectory();
+  stat = exclusive(this._stat);
+  private async _stat() {
+    return await fs.stat(this.absolute().path);
+  }
+
+  isDirectory = exclusive(this._isDirectory);
+  private async _isDirectory() {
+    return (await this._stat()).isDirectory();
   }
 
   /** ファイルの最終更新時刻を取得 */
-  async lastUpdateTime(): Promise<Date> {
-    return (await fs.stat(this.str())).mtime;
+  lastUpdateTime = exclusive(this._lastUpdateTime);
+  // TODO: DayJSの実装に置換
+  private async _lastUpdateTime(): Promise<Date> {
+    return (await fs.stat(this.path)).mtime;
   }
+  // private async _lastUpdateTime(): Promise<Dayjs> {
+  //   return dayjs((await fs.stat(this.path)).mtimeMs);
+  // }
 
-  async rename(newpath: Path) {
+  rename = exclusive(this._rename);
+  private async _rename(newpath: Path) {
     await newpath.parent().mkdir(true);
-    await fs.rename(this.path, newpath.absolute().str());
+    await fs.rename(this._path, newpath.absolute().path);
   }
 
-  async mkdir(recursive = false) {
-    if (!this.exists()) await fs.mkdir(this.path, { recursive });
+  mkdir = exclusive(this._mkdir);
+  private async _mkdir(recursive = true) {
+    if (!this.exists()) await fs.mkdir(this._path, { recursive });
   }
 
-  /** 同期ディレクトリ生成(非推奨) */
+  /** ディレクトリが無かったら作成する */
+  ensureDir = exclusive(this._ensureDir);
+  private async _ensureDir(options?: { mode?: number }) {
+    await fs.ensureDir(this._path, options);
+  }
+
+  /** ディレクトリが空の状態を保証する */
+  emptyDir = exclusive(this._emptyDir);
+  private async _emptyDir() {
+    await fs.emptyDir(this._path);
+  }
+
+  /** @deprecated 同期ディレクトリ生成(非推奨) */
   mkdirSync(recursive = false) {
-    if (!this.exists()) fs.mkdirSync(this.path, { recursive });
+    if (!this.exists()) fs.mkdirSync(this._path, { recursive });
   }
 
-  async mklink(target: Path) {
-    await new Promise((resolve) => fs.link(target.path, this.path, resolve));
+  mklink = exclusive(this._mklink);
+  private async _mklink(target: Path): Promise<Failable<void>> {
+    await this.parent().mkdir();
+    return await new Promise<Failable<void>>((resolve) =>
+      fs.link(target._path, this._path, (e) => {
+        e
+          ? resolve(
+              errorMessage.data.path.loadingFailed({
+                type: 'directory',
+                path: this.path,
+              })
+            )
+          : resolve();
+      })
+    );
   }
 
-  async write(content: BytesData) {
+  write = exclusive(this._write);
+  private async _write(content: BytesData) {
+    // TODO: エラーの戻り値を考慮して呼び出し元を修正
     await this.parent().mkdir(true);
-    await content.write(this.path);
+    return await content.write(this._path);
   }
 
-  async writeText(content: string) {
-    await this.parent().mkdir(true);
-    await fs.writeFile(this.path, content);
+  /**
+   * ファイルにテキストを書き込む
+   * @param content 書き込む内容
+   * @param encoding エンコード形式 デフォルト:utf-8
+   */
+  writeText = exclusive(this._writeText);
+  private async _writeText(
+    content: string,
+    encoding: BufferEncoding = 'utf8'
+  ): Promise<Failable<void>> {
+    // TODO: エラーの戻り値を考慮して呼び出し元を修正
+    const bytes = await (await loadBytesData()).fromText(content);
+    if (isError(bytes)) return bytes;
+    return await this._write(bytes);
   }
 
-  async appendText(content: string) {
-    await this.parent().mkdir(true);
-    await fs.appendFile(this.path, content);
-  }
-
-  /** 同期書き込み(非推奨) */
+  /** @deprecated 同期書き込み(非推奨) */
   writeTextSync(content: string) {
     this.parent().mkdirSync(true);
-    fs.writeFileSync(this.path, content);
+    fs.writeFileSync(this._path, content);
   }
 
-  async writeJson<T>(content: T) {
-    await this.parent().mkdir(true);
-    await fs.writeFile(this.path, JSON.stringify(content));
+  writeJson = exclusive(this._writeJson);
+  private async _writeJson<T>(content: T) {
+    return this._writeText(JSON.stringify(content));
   }
 
-  async read(): Promise<Failable<BytesData>> {
-    return await (await loadBytesData()).fromPath(this);
-  }
-
-  async readJson<T>(): Promise<Failable<T>> {
-    const data = await (await loadBytesData()).fromPath(this);
-    if (isError(data)) return data;
-    return await data.json();
-  }
-
-  async readText(): Promise<Failable<string>> {
-    const data = await (await loadBytesData()).fromPath(this);
-    if (isError(data)) return data;
-    return await data.text();
-  }
-
-  /** 非推奨 */
-  readBufferSync(): Buffer {
-    return fs.readFileSync(this.str());
-  }
-
-  async iter() {
-    if (this.exists() && (await this.isDirectory()))
-      return (await fs.readdir(this.path)).map((p) => this.child(p));
-    return [];
-  }
-
-  async remove() {
-    if (!this.exists()) return;
-
-    if (await this.isDirectory()) {
-      await fs.rm(this.path, { recursive: true });
-    } else {
-      await fs.unlink(this.path);
+  /**
+   * ファイルの末尾にテキストを追加
+   * @param encoding エンコード形式 デフォルト:utf-8
+   */
+  appendText = exclusive(this._appendText);
+  private async _appendText(
+    content: string,
+    encoding: BufferEncoding = 'utf8'
+  ) {
+    await this.parent().mkdir();
+    try {
+      await fs.appendFile(this._path, content, { encoding });
+    } catch {
+      // TODO: エラーの戻り値を考慮して呼び出し元を修正
+      return errorMessage.data.path.creationFailed({
+        type: 'file',
+        path: this.path,
+      });
     }
   }
 
-  async copyTo(target: Path) {
-    if (!this.exists()) return;
-    await target.parent().mkdir(true);
-    await target.remove();
-    await fs.copy(this.str(), target.str());
+  read = exclusive(this._read);
+  private async _read(): Promise<Failable<BytesData>> {
+    return (await loadBytesData()).fromPath(this);
   }
 
-  async moveTo(target: Path) {
+  readJson = exclusive(this._readJson);
+  private async _readJson<T>(): Promise<Failable<T>> {
+    const data = await this._read();
+    if (isError(data)) return data;
+    return data.json();
+  }
+
+  readText = exclusive(this._readText);
+  private async _readText(): Promise<Failable<string>> {
+    const data = await this._read();
+    if (isError(data)) return data;
+    return data.text();
+  }
+
+  /** @deprecated 非推奨 */
+  readBufferSync(): Buffer {
+    return fs.readFileSync(this.path);
+  }
+
+  iter = exclusive(this._iter);
+  private async _iter() {
+    if (this.exists() && (await this.isDirectory()))
+      return (await fs.readdir(this._path)).map((p) => this.child(p));
+    return [];
+  }
+
+  /**
+   * ファイル / ディレクトリ を再帰的に削除
+   */
+  remove = exclusive(this._remove);
+  private async _remove(): Promise<Failable<void>> {
+    try {
+      await fs.rm(this._path, { recursive: true, force: true });
+    } catch {
+      // TODO: エラーの戻り値を考慮して呼び出し元を修正
+      return errorMessage.data.path.deletionFailed({
+        type: (await this.isDirectory()) ? 'directory' : 'file',
+        path: this.path,
+      });
+    }
+  }
+
+  copyTo = exclusive(this._copyTo);
+  private async _copyTo(target: Path) {
     if (!this.exists()) return;
     await target.parent().mkdir(true);
     await target.remove();
+    await fs.copy(this.path, target.path);
+  }
+
+  moveTo = exclusive(this._moveTo);
+  private async _moveTo(target: Path): Promise<Failable<void>> {
+    if (!this.exists()) return;
+    await target.parent().mkdir(true);
+    const isSuccessRemove = await target.remove();
+    if (isError(isSuccessRemove)) return isSuccessRemove;
 
     // fs.moveだとうまくいかないことがあったので再帰的にファイルを移動
     async function recursiveMove(path: Path, target: Path) {
@@ -189,16 +290,22 @@ export class Path {
           await recursiveMove(child, target.child(child.basename()));
         });
       } else {
-        await fs.move(path.str(), target.str());
+        await fs.move(path.path, target.path);
       }
-      await path.remove();
+      const isSuccessRecRemove = await path.remove();
+      if (isError(isSuccessRecRemove)) return isSuccessRecRemove;
     }
-    await recursiveMove(this, target);
+    return await recursiveMove(this, target);
   }
 
   async changePermission(premission: number) {
-    await changePermissionsRecursively(this.path, premission);
+    await changePermissionsRecursively(this._path, premission);
   }
+
+  test = exclusive(async function (message: string) {
+    await sleep(300);
+    return 10;
+  });
 }
 
 /** 再帰的にファイルの権限を書き換える */
@@ -213,4 +320,208 @@ async function changePermissionsRecursively(basePath: string, mode: number) {
       }
     }
   }
+}
+
+const spoolers = InfinitMap.primitiveKeyWeakValue(
+  (key: string) => new PromiseSpooler()
+);
+function exclusive<P extends any[], R>(
+  target: (this: Path, ...args: P) => Promise<R>
+) {
+  return function (this: Path, ...args: P) {
+    const key = this.absolute().path;
+    return spoolers.get(key).spool(() => target.bind(this)(...args));
+  };
+}
+
+/** In Source Testing */
+if (import.meta.vitest) {
+  const { test, expect } = import.meta.vitest;
+  test('path', () => {
+    // パス操作のテスト
+    expect(new Path('.').path).toBe('.');
+    expect(new Path('./').path).toBe('.');
+    expect(new Path('').path).toBe('.');
+
+    expect(new Path('..').path).toBe('..');
+    expect(new Path('../').path).toBe('..');
+
+    expect(new Path('./').child('foo').path).toBe('foo');
+    expect(new Path('./').child('foo/').path).toBe('foo');
+    expect(new Path('./').child('/foo/').path).toBe('foo');
+
+    expect(new Path('./').child('foo').path).toBe('foo');
+    expect(new Path('./').child('/foo/').path).toBe('foo');
+
+    expect(new Path('./').child('foo/bar').path).toBe(new Path('foo/bar').path);
+    expect(new Path('./').child('foo\\bar').path).toBe(
+      new Path('foo/bar').path
+    );
+    expect(new Path('./').child('foo', 'bar').path).toBe(
+      new Path('foo/bar').path
+    );
+    expect(new Path('./').child('/foo/', '/bar/', '/buz/').path).toBe(
+      new Path('foo/bar/buz').path
+    );
+
+    expect(new Path('foo').path).toBe('foo');
+    expect(new Path('foo/').path).toBe('foo');
+
+    expect(new Path('foo').child('bar').path).toBe(new Path('foo/bar').path);
+    expect(new Path('foo/').child('/bar/').path).toBe(new Path('foo/bar').path);
+
+    expect(new Path('foo/bar').parent().path).toBe(new Path('foo').path);
+    expect(new Path('foo/bar').parent(2).path).toBe(new Path('').path);
+  });
+
+  test('file', async () => {
+    // ファイル操作のテスト
+    const testdir = new Path('./userData/test');
+
+    // testdirの中身をリセット (正直これができてる時点で見たいな話はある)
+    await testdir.remove();
+    await testdir.mkdir();
+
+    // ディレクトリの生成/削除
+    const a = testdir.child('a');
+    expect(a.exists()).toBe(false);
+    await a.mkdir();
+    // 存在するディレクトリを生成しても何も起こらない
+    await a.mkdir();
+    expect(a.exists()).toBe(true);
+    await a.remove();
+    // 存在しないディレクトリを削除しても何も起こらない
+    await a.remove();
+    expect(a.exists()).toBe(false);
+
+    // ファイルの生成/削除
+    await a.mkdir();
+    const b = a.child('b');
+    await b.writeText('hello');
+    expect(await b.readText()).toBe('hello');
+    await b.remove();
+    expect(b.exists()).toBe(false);
+    await a.remove();
+
+    // ディレクトリの再帰的な作成/削除
+    expect(a.exists()).toBe(false);
+    await b.mkdir();
+    expect(b.exists()).toBe(true);
+    await a.remove();
+    expect(a.exists()).toBe(false);
+  });
+
+  // TODO: テストを貼り付けただけのため，今回の実装に合うよう換装する -> stream関連は基本的に不要？
+  // test('stream', async () => {
+  //   // ストリームのテスト
+  //   const testdir = new Path('./userData/test');
+
+  //   // testdirの中身をリセット
+  //   await testdir.remove();
+  //   await testdir.mkdir();
+
+  //   const src = testdir.child('src.txt');
+  //   const tgt = testdir.child('tgt.txt');
+  //   const mis = testdir.child('mis.txt');
+
+  //   // ファイルの中身をコピー
+  //   await src.writeText('hello world');
+  //   expect(await src.readText()).toBe('hello world');
+
+  //   expect(tgt.exists()).toBe(false);
+
+  //   await src.into(tgt);
+
+  //   expect(await tgt.readText()).toBe('hello world');
+  //   await tgt.remove();
+
+  //   const { Bytes } = await import('./bytes');
+
+  //   // ファイルの中身をバイト列に変換
+  //   const bytes = await src.into(Bytes);
+
+  //   expect(bytes.data.toString('utf8')).toBe('hello world');
+
+  //   expect(tgt.exists()).toBe(false);
+
+  //   // バイト列をファイルに書き込み
+  //   await bytes.into(tgt);
+
+  //   expect(await tgt.readText()).toBe('hello world');
+
+  //   await tgt.remove();
+
+  //   expect((await mis.into(Bytes)).error().message).toContain('ENOENT');
+
+  //   // TODO: 失敗するストリームの調査
+  //   // TODO: すでにあるファイルにストリームを書き込めないことを検証
+  //   // TODO: ストリームの書き込みに失敗した場合にファイルが削除されることを確認
+
+  //   // 後片付け
+  //   await testdir.remove();
+
+  //   // await bytes.into(tgt);
+
+  //   // await bytes.convert(fromSHIFTJIS).into(tgt);
+  //   // await bytes.convert(toSHIFTJIS).into(tgt);
+
+  //   // await bytes.convert(fromBase64).into(tgt);
+  //   // await bytes.convert(toBase64).into(tgt);
+
+  //   // await bytes.convert(fromGZ).into(tgt);
+  //   // await bytes.convert(toGZ).into(tgt);
+
+  //   // await bytes.into(SHA256);
+  //   // await bytes.into(SHA128);
+  // });
+
+  test('exclusive', async () => {
+    const p1 = new Path('test1');
+    const p2 = new Path('test2');
+    await Promise.all([
+      p1.test('01'),
+      p1.test('02'),
+      p1.parent().child('test1').test('03'),
+    ]);
+    sleep(1000);
+    await Promise.all([p1.test('11'), p2.test('12')]);
+  });
+
+  describe.skip('Path file operations with busy resources', () => {
+    test('write to opened file should handle EBUSY error', async () => {
+      const testPath = new Path('test.txt');
+
+      // ファイルを開いたままにする
+      const fileHandle = fs.openSync(testPath.path, 'w');
+
+      // 開いているファイルに書き込みを試みる
+      const writeResult = await testPath.writeText('test content');
+
+      // クリーンアップ
+      fs.closeSync(fileHandle);
+      await testPath.remove();
+
+      // エラーがFailableとして適切に返されることを確認
+      // TODO: EBUSY errorをうまく再現できていないため，要検証
+      expect(isError(writeResult)).toBe(true);
+    });
+
+    test('remove opened file should handle EBUSY error', async () => {
+      const testPath = new Path('test2.txt');
+      await testPath.writeText('initial content');
+
+      // ファイルを開いたままにする
+      const fileHandle = fs.openSync(testPath.path, 'r');
+
+      // 開いているファイルの削除を試みる
+      const removeResult = await testPath.remove();
+
+      // クリーンアップ
+      fs.closeSync(fileHandle);
+      await testPath.remove();
+
+      // エラーがFailableとして適切に返されることを確認
+      expect(isError(removeResult)).toBe(true);
+    });
+  });
 }

--- a/src-electron/util/binary/path.ts
+++ b/src-electron/util/binary/path.ts
@@ -194,7 +194,6 @@ export class Path {
     content: string,
     encoding: BufferEncoding = 'utf8'
   ): Promise<Failable<void>> {
-    // TODO: エラーの戻り値を考慮して呼び出し元を修正
     const bytes = await (await loadBytesData()).fromText(content);
     if (isError(bytes)) return bytes;
     return this._write(bytes);
@@ -208,7 +207,6 @@ export class Path {
 
   writeJson = exclusive(this._writeJson);
   private async _writeJson<T>(content: T) {
-    // TODO: エラーの戻り値を考慮して呼び出し元を修正
     return this._writeText(JSON.stringify(content));
   }
 
@@ -225,7 +223,6 @@ export class Path {
     try {
       await fs.appendFile(this._path, content, { encoding });
     } catch {
-      // TODO: エラーの戻り値を考慮して呼び出し元を修正
       return errorMessage.data.path.creationFailed({
         type: 'file',
         path: this.path,

--- a/src-electron/util/binary/path.ts
+++ b/src-electron/util/binary/path.ts
@@ -256,7 +256,6 @@ export class Path {
 
   async iter(): Promise<Failable<Path[]>> {
     const isDir = await this._isDirectory();
-    // TODO: エラーの戻り値を考慮して呼び出し元を修正
     if (isError(isDir)) return isDir;
 
     if (this.exists() && isDir)
@@ -276,7 +275,6 @@ export class Path {
     try {
       await fs.rm(this._path, { recursive: true, force: true });
     } catch {
-      // TODO: エラーの戻り値を考慮して呼び出し元を修正
       return errorMessage.data.path.deletionFailed({
         type: isDir ? 'directory' : 'file',
         path: this.path,
@@ -292,7 +290,6 @@ export class Path {
     await fs.copy(this.path, target.path);
   }
 
-  // TODO: エラーの戻り値を考慮して呼び出し元を修正
   moveTo = exclusive(this._moveTo);
   private async _moveTo(target: Path): Promise<Failable<void>> {
     if (!this.exists()) return;

--- a/src-electron/util/binary/path.ts
+++ b/src-electron/util/binary/path.ts
@@ -71,14 +71,14 @@ export class Path {
     return `"${this._path.replace('\\', '\\\\').replace('"', '\\"')}"`;
   }
 
-  /** @deprecated TODO: .pathへ修正*/
+  /** @deprecated .pathを用いること*/
   str() {
-    return this._path;
+    return this.path;
   }
 
-  /** @deprecated TODO: .quotedPathへ修正 */
+  /** @deprecated .quotedPathを用いること */
   strQuoted() {
-    return `"${this._path.replace('\\', '\\\\').replace('"', '\\"')}"`;
+    return this.quotedPath;
   }
 
   /** ディレクトリ階層を除いたファイル名を返す ".../../file.txt" -> "file.txt" */

--- a/src-electron/util/error/schema/data.ts
+++ b/src-electron/util/error/schema/data.ts
@@ -56,7 +56,10 @@ export type DataErrors = {
     invalidContent: PathContentErrors;
 
     // ファイルまたはディレクトリの生成に失敗
-    creationFiled: PathErrorContent;
+    creationFailed: PathErrorContent;
+
+    // ファイルまたはディレクトリの削除に失敗
+    deletionFailed: PathErrorContent;
 
     // ファイル選択ウィンドウがキャンセルされた場合
     dialogCanceled: ErrorMessageContent;

--- a/src-electron/util/error/schema/data.ts
+++ b/src-electron/util/error/schema/data.ts
@@ -40,6 +40,9 @@ export type DataErrors = {
     // ファイル/ディレクトリの読み込みに失敗したときのエラー
     loadingFailed: PathErrorContent;
 
+    // ファイル/ディレクトリのリネームに失敗したときのエラー
+    renameFailed: PathErrorContent;
+
     // ファイルまたはディレクトリがすでに存在する
     alreadyExists: PathErrorContent;
 

--- a/src-electron/util/helper/infinitMap.ts
+++ b/src-electron/util/helper/infinitMap.ts
@@ -1,0 +1,120 @@
+type DymanicRecordOptions<K, V> = {
+  /** valueの初期値コンストラクタ */
+  init: () => V;
+};
+
+/**
+ * 任意のキーにアクセスして常に必ず値を返すMap
+ *
+ * 初期化関数を受け取り、始めてアクセスされるキーの場合に内部で実行する
+ */
+export class InfinitMap<K, V> {
+  private init: (key: K) => V;
+  private getter: (key: K) => V | undefined;
+  private setter: (key: K, value: V) => void;
+
+  private constructor(
+    init: (key: K) => V,
+    getter: (key: K) => V | undefined,
+    setter: (key: K, value: V) => void
+  ) {
+    this.init = init;
+    this.getter = getter;
+    this.setter = setter;
+  }
+
+  /** 誰からも参照されなくなった値も残り続ける */
+  static objectKeyStrongValue<K extends object, V extends object>(
+    init: (key: K) => V
+  ): InfinitMap<K, V> {
+    const map = new WeakMap<K, V>();
+    const getter = (k: K) => map.get(k);
+    const setter = (k: K, v: V) => map.set(k, v);
+    return new InfinitMap(init, getter, setter);
+  }
+
+  /**
+   * 誰からも参照されなくなった値は自動で削除される
+   * @see https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Global_Objects/WeakRef
+   */
+  static objectKeyWeakValue<K extends object, V extends object>(
+    init: (key: K) => V
+  ): InfinitMap<K, V> {
+    const map = new WeakMap<K, WeakRef<V>>();
+    const getter = (k: K) => map.get(k)?.deref();
+    const setter = (k: K, v: V) => map.set(k, new WeakRef(v));
+    return new InfinitMap(init, getter, setter);
+  }
+
+  static objectKeyPrimitiveValue<
+    K extends object,
+    V extends number | string | boolean
+  >(init: (key: K) => V): InfinitMap<K, V> {
+    const map = new WeakMap<K, V>();
+    const getter = (k: K) => map.get(k);
+    const setter = (k: K, v: V) => map.set(k, v);
+    return new InfinitMap(init, getter, setter);
+  }
+
+  /** 誰からも参照されなくなった値も残り続ける */
+  static primitiveKeyStrongValue<K extends number | string, V extends object>(
+    init: (key: K) => V
+  ): InfinitMap<K, V> {
+    const map = {} as Record<K, V>;
+    const getter = (k: K) => map[k];
+    const setter = (k: K, v: V) => (map[k] = v);
+    return new InfinitMap(init, getter, setter);
+  }
+
+  /**
+   * 誰からも参照されなくなった値は自動で削除される
+   * @see https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Global_Objects/WeakRef
+   */
+  static primitiveKeyWeakValue<K extends number | string, V extends object>(
+    init: (key: K) => V
+  ): InfinitMap<K, V> {
+    const map = {} as Record<K, WeakRef<V>>;
+    const getter = (k: K) => map[k]?.deref();
+    const setter = (k: K, v: V) => (map[k] = new WeakRef(v));
+    return new InfinitMap(init, getter, setter);
+  }
+
+  static primitiveKeyPrimitiveValue<
+    K extends number | string,
+    V extends number | string | boolean
+  >(init: (key: K) => V): InfinitMap<K, V> {
+    const map = {} as Record<K, V>;
+    const getter = (k: K) => map[k];
+    const setter = (k: K, v: V) => (map[k] = v);
+    return new InfinitMap(init, getter, setter);
+  }
+
+  /** キーに対する値を取得する、存在しない場合生成する */
+  get(key: K): V {
+    const val = this.getter(key);
+    if (val !== undefined) return val;
+    const newVal = this.init(key);
+    this.setter(key, newVal);
+    return newVal;
+  }
+
+  set(key: K, value: V) {
+    this.setter(key, value);
+  }
+}
+
+/** In Source Testing */
+if (import.meta.vitest) {
+  const { describe, test, expect } = import.meta.vitest;
+  describe('InfinitMap', () => {
+    test('key:primitive value:primitive', () => {
+      const map = InfinitMap.primitiveKeyPrimitiveValue<string, string>(
+        () => 'init'
+      );
+      expect(map.get('foo')).toBe('init');
+      map.set('foo', 'modified');
+      expect(map.get('foo')).toBe('modified');
+      expect(map.get('bar')).toBe('init');
+    });
+  });
+}

--- a/src-electron/util/promise/spool.ts
+++ b/src-electron/util/promise/spool.ts
@@ -1,0 +1,108 @@
+/**
+ * プロミスを直列実行するためのクラス
+ *
+ * 並列で処理されると問題が起こる場合に、あとから登録されたプロミスは前のプロミスがすべて終わるまで待機してから実行される
+ */
+export class PromiseSpooler {
+  private spooling: (() => Promise<void>)[];
+
+  constructor() {
+    this.spooling = [];
+  }
+
+  // 実行中のプロミスが存在するか
+  hasSpooled(): boolean {
+    return this.spooling.length !== 0;
+  }
+
+  async spool<T>(promise: () => Promise<T>): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+      // 待機列の先頭に来た時に呼ばれる
+      const lazeInvoke = async () => {
+        try {
+          resolve(await promise());
+        } catch (e) {
+          reject(e);
+        } finally {
+          this.spooling.shift();
+          // 次のlazeInvokeがあるなら呼び出す
+          this.spooling[0]?.();
+        }
+      };
+
+      // 待機列の最後にlazeInvokeを追加
+      this.spooling.push(lazeInvoke);
+      // 待機列が自分だけだったら即座に実行
+      if (this.spooling.length === 1) lazeInvoke();
+    });
+  }
+}
+
+/** In Source Testing */
+if (import.meta.vitest) {
+  const { describe, test, expect } = import.meta.vitest;
+  const { sleep } = await import('./sleep');
+
+  describe('Promise直列化のテスト', () => {
+    test('プロミス1つで問題なく動く', async () => {
+      const spooler = new PromiseSpooler();
+
+      expect(spooler.hasSpooled(), '実行中のプロミスはない').toBe(false);
+
+      const log: string[] = [];
+
+      const promise1 = spooler.spool(async () => {
+        log.push('1 start');
+        await sleep(100);
+        log.push('1 end');
+        return 1;
+      });
+
+      expect(spooler.hasSpooled(), '実行中のプロミスあり').toBe(true);
+
+      expect(await promise1).toBe(1);
+
+      expect(spooler.hasSpooled(), '実行中のプロミスはない').toBe(false);
+      expect(log, '実行中のプロミスはない').toEqual(['1 start', '1 end']);
+    });
+
+    test('プロミス複数が直列実行される', async () => {
+      const spooler = new PromiseSpooler();
+
+      expect(spooler.hasSpooled(), '実行中のプロミスはない').toBe(false);
+
+      const log: string[] = [];
+
+      const promise1 = spooler.spool(async () => {
+        log.push('1 start');
+        await sleep(100);
+        log.push('1 end');
+        return 1;
+      });
+      const promise2 = spooler.spool(async () => {
+        log.push('2 start');
+        await sleep(200);
+        log.push('2 end');
+        return 2;
+      });
+
+      expect(spooler.hasSpooled(), '実行中のプロミスあり').toBe(true);
+      expect(log, '実行順の確認').toEqual(['1 start']);
+
+      expect(await promise1).toBe(1);
+
+      expect(spooler.hasSpooled(), '実行中のプロミスあり').toBe(true);
+      expect(log, '実行順の確認').toEqual(['1 start', '1 end', '2 start']);
+
+      expect(await promise2).toBe(2);
+
+      expect(spooler.hasSpooled(), '実行中のプロミスなし').toBe(false);
+      expect(log, '実行順の確認').toEqual([
+        '1 start',
+        '1 end',
+        '2 start',
+        '2 end',
+      ]);
+    });
+  });
+}

--- a/src-electron/util/promise/spool.ts
+++ b/src-electron/util/promise/spool.ts
@@ -41,9 +41,10 @@ export class PromiseSpooler {
 /** In Source Testing */
 if (import.meta.vitest) {
   const { describe, test, expect } = import.meta.vitest;
-  const { sleep } = await import('./sleep');
 
-  describe('Promise直列化のテスト', () => {
+  describe('Promise直列化のテスト', async () => {
+    const { sleep } = await import('./sleep');
+
     test('プロミス1つで問題なく動く', async () => {
       const spooler = new PromiseSpooler();
 

--- a/src/i18n/en-US/Other/error.ts
+++ b/src/i18n/en-US/Other/error.ts
@@ -103,9 +103,13 @@ export const enUSError: MessageSchema['error'] = {
           desc: '{path} is inappropriate',
         },
       },
-      creationFiled: {
+      creationFailed: {
         title: 'Failed to create {type}',
-        desc: 'failed to create {path}',
+        desc: 'Failed to create {path}',
+      },
+      deletionFailed: {
+        title: 'Failed to delete {type}',
+        desc: 'Failed to delete {path}',
       },
       dialogCanceled: {
         title: 'Window to select file is cancelled',

--- a/src/i18n/en-US/Other/error.ts
+++ b/src/i18n/en-US/Other/error.ts
@@ -46,6 +46,10 @@ export const enUSError: MessageSchema['error'] = {
         title: 'Failed to read the {type}',
         desc: 'failed for {path}',
       },
+      renameFailed: {
+        title: 'Failed to rename the {type}',
+        desc: 'failed for {path}',
+      },
       alreadyExists: {
         title: '{type} already exists',
       },

--- a/src/i18n/ja/Other/error.ts
+++ b/src/i18n/ja/Other/error.ts
@@ -48,6 +48,10 @@ export const jaError: ErrorTranslationTypes & ErrorDialogTitles = {
         title: '{type}の読み込みに失敗しました',
         desc: '{path}を読み込めませんでした',
       },
+      renameFailed: {
+        title: '{type}のリネームに失敗しました',
+        desc: '{path}をリネームできませんでした',
+      },
       alreadyExists: {
         title: '{type}が既に存在しています',
       },

--- a/src/i18n/ja/Other/error.ts
+++ b/src/i18n/ja/Other/error.ts
@@ -105,9 +105,13 @@ export const jaError: ErrorTranslationTypes & ErrorDialogTitles = {
           desc: '{path}の中身が不適当です',
         },
       },
-      creationFiled: {
+      creationFailed: {
         title: '{type}の生成に失敗しました',
         desc: '{path}の生成ができませんでした',
+      },
+      deletionFailed: {
+        title: '{type}の削除に失敗しました',
+        desc: '{path}の削除ができませんでした',
       },
       dialogCanceled: {
         title: 'ファイル選択ウィンドウがキャンセルされました',


### PR DESCRIPTION
# 概要

Pathの実装をV2側より移築実装

移築によって下記の機能が追加される

- パスに関連する操作の排他制御
- `lastUpdateTime()`のDayjs実装
- ファイル or フォルダ削除失敗時のエラーメッセージ追加

今回の変更によって下記の問題が修正された
- ファイル変更が競合した際に無限停止となる問題
- ファイル書き込み中に次の読み込み処理が入った際に，読み込み側の処理がエラーとなる問題