### PR TITLE
V2のloggerを統合

### DIFF
--- a/src-electron/common/logger.md
+++ b/src-electron/common/logger.md
@@ -1,0 +1,113 @@
+# ログ出力のガイドライン
+
+更新 2024-08-01
+
+# v2/common/logger の使い方
+
+setWorldMeta で使用する場合の例
+
+```ts
+class LocalWorldSource {
+  setWorldMeta(worldName: WorldName, world: World) {
+    // ロガーを作成
+    const logger = rootLogger.source.world.local.setWorldMeta({
+      worldName: worldName,
+    });
+    // ログを出力
+    logger.trace('success');
+  }
+}
+```
+
+### ポイント 1
+
+```ts
+rootLogger.source.world.local.setWorldMeta;
+```
+
+ロガーは階層化できるので `rootLogger.source.{ソース種別}.{細別}.{メソッド名}` といったように階層化する。
+階層数はわかりやすいように決めて OK。階層は`camelCase`で記述する。
+
+### ポイント 2
+
+```ts
+...setWorldMeta({ worldName: 'NewWorld' })
+```
+
+ロガーは引数を設定できるので(省略可)、階層とは関係ない呼び出し時のデータは引数に設定するとよい。
+ただしログの内容を簡潔にするため、呼び出し時の状態が伝わる最低限のデータを渡すこと。
+引数には json 化できる値をいくつでも設定できる。(ただし簡潔に)
+
+### ポイント 3
+
+```ts
+logger.trace('success');
+```
+
+ログ出力にも引数を設定でき(省略可)、引数には json 化できる値をいくつでも設定できる。(ただし簡潔に)
+
+ログはレベル下から順に `trace / debug / info / warn / error / fatal` を選択できる。
+
+正直使い分けはいまいちわからないけど、いったん下記のイメージで。使いながら固めていきたい。
+
+##### trace
+
+一応出しとくか程度 console.log くらいの気分
+
+- ipc 通信のログ
+- ファイル操作のログ
+
+##### debug
+
+特定の条件でしか走らない処理が走った時
+
+- キャッシュがなかったので再取得した
+
+##### info
+
+そこそこ時間がかかる / 十分エラーが起きうる操作が 開始/終了したとき
+
+- java のインストール
+- spigot のビルド
+- rclone の同期
+
+##### warn
+
+ちょっと強引だけど解決した / 無視して続行した
+
+- サーバー設定ファイルがないワールドを開いた
+- キャッシュデータのハッシュ値が合わない
+
+##### error
+
+操作がエラーになった
+操作は完了できないけどアプリは落ちない
+
+- URL にアクセスできなかった
+- サーバーが異常終了した
+
+##### fatal
+
+アプリが異常終了するレベルのエラー
+吐くことなさそう
+
+# 伏字
+
+ログ出力設定として伏字を設定できる。現状文字列置換のみ対応
+
+下記のように値とパスを受け取って伏字処理を施す関数を追加できる
+
+伏字ルールはどこかにまとめて記述予定 (記述場所未定) なのでまだ使わないでおいてください
+
+```ts
+// 値が /SECRET_TOKEN/ にマッチしたら "***" に置換してログ出力.
+addOmisstionRule((value) => (value.test(/SECRET_TOKEN/) ? ok('***') : err()));
+```
+
+path は下記のように渡される
+
+```ts
+logger.trace('foo'); // {value:'foo', path:[]} で呼ばれる
+logger.trace(10, 'foo'); // {value:'foo', path:[1]} で呼ばれる
+logger.trace({ test: [0, 'foo'] }); // {value:'foo', path:['test',1]} で呼ばれる
+```

--- a/src-electron/common/logger.md
+++ b/src-electron/common/logger.md
@@ -101,7 +101,7 @@ logger.trace('success');
 
 ```ts
 // 値が /SECRET_TOKEN/ にマッチしたら "***" に置換してログ出力.
-addOmisstionRule((value) => (value.test(/SECRET_TOKEN/) ? ok('***') : err()));
+addOmisstionRule((value) => (value.test(/SECRET_TOKEN/) ? '***' : value));
 ```
 
 path は下記のように渡される

--- a/src-electron/common/logger.ts
+++ b/src-electron/common/logger.ts
@@ -46,23 +46,27 @@ function truncateValue(value: any, depth = 0): string {
   if (depth > 2) return '...'; // ネストが深すぎる場合は省略
 
   if (Array.isArray(value)) {
-    if (value.length <= MAX_ARRAY_ITEMS * 2) {
+    const remainItems = value.length - MAX_ARRAY_ITEMS * 2;
+    // ... N more ... 表示はN=2以上とする
+    if (remainItems <= 1) {
       // 配列の場合，深さ`depth`は深くなっていないと判断して，`depth + 1`としない
       return `[${value.map((v) => truncateValue(v, depth)).join(', ')}]`;
     }
     const first = value.slice(0, MAX_ARRAY_ITEMS);
     const last = value.slice(-MAX_ARRAY_ITEMS);
-    return `[${first.map((v) => truncateValue(v, depth)).join(', ')}, ... ${
-      value.length - MAX_ARRAY_ITEMS * 2
-    } more ..., ${last.map((v) => truncateValue(v, depth)).join(', ')}]`;
+    return `[${first
+      .map((v) => truncateValue(v, depth))
+      .join(', ')}, ... ${remainItems} more ..., ${last
+      .map((v) => truncateValue(v, depth))
+      .join(', ')}]`;
   }
 
   if (typeof value === 'string') {
     if (value.length > MAX_STRING_LENGTH) {
       const half = Math.floor(MAX_STRING_LENGTH / 2);
-      return `${value.slice(0, half)}...${value.slice(-half)}`;
+      return `${value.slice(0, half)}...${value.slice(-half)}`.trim();
     }
-    return value;
+    return value.trim();
   }
 
   if (typeof value === 'object' && value !== null) {

--- a/src-electron/common/logger.ts
+++ b/src-electron/common/logger.ts
@@ -37,7 +37,7 @@ if (app && logPaths.every((path) => path.exists())) {
  */
 function truncateValue(value: any, depth = 0): string {
   const MAX_ARRAY_ITEMS = 1;
-  const MAX_OBJECT_ITEMS = 3;
+  const MAX_OBJECT_FIELDS = 3;
   const MAX_STRING_LENGTH = 50;
 
   if (depth > 2) return '...'; // ネストが深すぎる場合は省略
@@ -69,15 +69,17 @@ function truncateValue(value: any, depth = 0): string {
   if (typeof value === 'object' && value !== null) {
     const entries = Object.entries(value);
     if (entries.length === 0) return '{}';
-    if (entries.length > MAX_OBJECT_ITEMS) {
-      const important = entries.slice(0, MAX_OBJECT_ITEMS);
-      return `{ ${important
+    const remainFields = entries.length - MAX_OBJECT_FIELDS;
+    // ... N more ... 表示はN=2以上とする
+    if (remainFields <= 1) {
+      return `{ ${entries
         .map(([k, v]) => `${k}: ${truncateValue(v, depth + 1)}`)
-        .join(', ')}, ... ${entries.length - MAX_OBJECT_ITEMS} more fields }`;
+        .join(', ')} }`;
     }
-    return `{ ${entries
+    const important = entries.slice(0, MAX_OBJECT_FIELDS);
+    return `{ ${important
       .map(([k, v]) => `${k}: ${truncateValue(v, depth + 1)}`)
-      .join(', ')} }`;
+      .join(', ')}, ... ${remainFields} more fields }`;
   }
 
   return String(value);
@@ -470,17 +472,15 @@ if (import.meta.vitest) {
       // オブジェクトの要素が3つ以上の場合は「．．．」で省略される
       {
         sourceParam: {
-          type: 'error',
-          key: 'data.url.fetch',
-          level: 'error',
-          arg: {
-            url: 'https://api.github.com/repos/Server-Starter-for-Minecraft/ServerStarter2/releases',
-            status: 401,
-            statusText: 'Unauthorized',
-          },
+          'accepts-transfers': false,
+          'allow-flight': false,
+          'allow-nether': true,
+          'broadcast-console-to-ops': true,
+          'broadcast-rcon-to-ops': true,
+          difficulty: 'easy',
         },
         expectStr:
-          '{ type: error, key: data.url.fetch, level: error, ... 1 more fields }',
+          '{ accepts-transfers: false, allow-flight: false, allow-nether: true, ... 3 more fields }',
       },
       // 配列の要素が3つ以上の場合は「．．．」で省略される
       {

--- a/src-electron/common/logger.ts
+++ b/src-electron/common/logger.ts
@@ -9,6 +9,7 @@ import { Path } from '../util/binary/path';
 import { isError } from '../util/error/error';
 import { InfinitMap } from '../util/helper/infinitMap';
 
+const TIME_FORMAT = 'YYYY-MM-DD HH:mm:ss.SSS';
 const LATEST = 'latest.log';
 const TMP_LOG = `tmp.${randomInt(2 ** 31)}`;
 const ARCHIVE_EXT = '.log.gz';
@@ -73,10 +74,12 @@ function truncateValue(value: any, depth = 0): string {
 
 log4js.addLayout('fullLog', () => {
   return (logEvent) => {
+    const time = dayjs(logEvent.startTime).format(TIME_FORMAT);
     const level = logEvent.level.levelStr;
     const category = logEvent.categoryName;
     const param = logEvent.data[0];
     const json = {
+      t: time,
       lv: level,
       on: category,
       param,
@@ -89,11 +92,11 @@ log4js.addLayout('truncateLog', () => {
   return (logEvent) => {
     const level = logEvent.level.levelStr.padEnd(5);
     const category = logEvent.categoryName;
-    const time = dayjs(logEvent.startTime).format('HH:mm:ss.SSS');
+    const time = dayjs(logEvent.startTime).format(TIME_FORMAT);
     const param = logEvent.data[0];
     const msg = logEvent.data[1];
 
-    let output = `[${time}] ${level} ${category}`;
+    let output = `[${level} ${time}] ${category}`;
     if (param !== undefined) {
       output += ` (${truncateValue(param)})`;
     }

--- a/src-electron/common/logger.ts
+++ b/src-electron/common/logger.ts
@@ -54,9 +54,7 @@ log4js.configure({
 // #endregion
 
 /** 過去のログをアーカイブ開始 */
-onQuit(() => {
-  if (latestPath) archiveLog(latestPath);
-}, true);
+onQuit(() => archiveLog(latestPath), true);
 
 /** パスにあるログをアーカイブする */
 async function archiveLog(logPath: Path) {

--- a/src-electron/common/logger.ts
+++ b/src-electron/common/logger.ts
@@ -19,8 +19,10 @@ const latestPath = logDir.child(LATEST);
 const beforeArchivePath = latestPath.parent().child(TMP_LOG);
 
 // LATASTの上書き前にアーカイブファイルを作成
-fs.copyFileSync(latestPath.path, beforeArchivePath.path);
-archiveLog(beforeArchivePath);
+if (latestPath.exists()) {
+  fs.copyFileSync(latestPath.path, beforeArchivePath.path);
+  archiveLog(beforeArchivePath);
+}
 
 // #region log4jsの設定
 
@@ -122,8 +124,8 @@ log4js.configure({
     file: { type: 'logLevelFilter', appender: '_file', level: 'trace' },
   },
   categories: {
-    default: { appenders: ['out', 'file'], level: 'trace' },
-    // default: { appenders: ['file'], level: 'trace' },
+    // default: { appenders: ['out', 'file'], level: 'trace' },
+    default: { appenders: ['file'], level: 'trace' },
   },
 });
 

--- a/src-electron/common/logger.ts
+++ b/src-electron/common/logger.ts
@@ -1,41 +1,24 @@
+import { randomInt } from 'crypto';
 import dayjs, { Dayjs } from 'dayjs';
+import * as fs from 'fs-extra';
 import log4js from 'log4js';
-import { c } from 'tar';
+import { Failable } from '../schema/error';
+import { logDir } from '../source/const';
+import { gzip } from '../util/binary/archive/gz';
 import { Path } from '../util/binary/path';
 import { isError } from '../util/error/error';
+import { InfinitMap } from '../util/helper/infinitMap';
 
 const LATEST = 'latest.log';
 const ARCHIVE_EXT = '.log.gz';
 
-// ログファイルをtar.gzに圧縮して保存
-async function compressArchive(logDir: Path, latestLog: Path) {
-  const [logName, archivePath] = getArchivePath(
-    logDir,
-    await latestLog.lastUpdateTime()
-  );
+fs.ensureDirSync(logDir.path);
+const latestPath = logDir.child('latest.log');
 
-  const newlogPath = logDir.child(logName);
-  await newlogPath.remove();
+// #region log4jsの設定
 
-  await latestLog.copyTo(newlogPath);
-
-  await c(
-    {
-      gzip: true,
-      file: archivePath.path,
-      cwd: logDir.path,
-    },
-    [logName]
-  );
-  await newlogPath.remove();
-}
-
-function stringify(data: any) {
-  return JSON.stringify(data, (k, v) => (v === undefined ? 'undefined' : v));
-}
-
-log4js.addLayout('custom', function () {
-  return function (logEvent) {
+log4js.addLayout('custom', () => {
+  return (logEvent) => {
     const level = logEvent.level.levelStr;
     const category = logEvent.categoryName;
     const state = logEvent.data[0];
@@ -49,47 +32,52 @@ log4js.addLayout('custom', function () {
       data: logEvent.data.slice(2),
     };
 
-    return stringify(json);
-
-    // const data = logEvent.data
-    //   .slice(2)
-    //   .map((d) => {
-    //     let text = stringify(d);
-    //     if (config.max && text.length > config.max) {
-    //       text = text.slice(undefined, config.max - 3) + '...';
-    //     }
-    //     return text;
-    //   })
-    //   .join(', ');
-
-    // if (data === '') return `[${level}/${state}] ${category} (${args})`;
-
-    // return `[${level}/${state}] ${category} (${args}): ${data}`;
+    return JSON.stringify(json);
   };
 });
 
-function getArchivePath(logDir: Path, time: Dayjs) {
-  let i = 0;
-  const format = time.format('YYYY-MM-DD-HH');
-  while (true) {
-    const path = logDir.child(`${format}-${i}${ARCHIVE_EXT}`);
-    if (!path.exists()) {
-      return [`${format}-${i}.log`, path] as const;
-    }
-    i += 1;
-  }
-}
+log4js.configure({
+  appenders: {
+    _out: {
+      type: 'stdout',
+      layout: { type: 'custom', max: 500 },
+    },
+    _file: {
+      type: 'file',
+      filename: logDir.child(LATEST).path,
+      layout: { type: 'custom', max: 500 },
+    },
+    out: { type: 'logLevelFilter', appender: '_out', level: 'warn' },
+    file: { type: 'logLevelFilter', appender: '_file', level: 'trace' },
+  },
+  categories: {
+    default: { appenders: ['out', 'file'], level: 'trace' },
+  },
+});
 
-async function archiveLog(logDir: Path) {
+// #endregion
+
+/** 過去のログをアーカイブ開始 */
+if (latestPath) archiveLog(latestPath);
+
+/** パスにあるログをアーカイブする */
+async function archiveLog(logPath: Path) {
   // .latestを圧縮してアーカイブ
   const latestLog = logDir.child(LATEST);
   if (latestLog.exists()) {
-    await compressArchive(logDir, latestLog);
+    const lastUpdateTime = dayjs(fs.statSync(logDir.path).mtimeMs);
+    const tmp = logDir.child(`tmp.${randomInt(2 ** 31)}`);
+    await logPath.moveTo(tmp, { overwrite: true });
+    const compressed = await gzip.fromFile(tmp);
+    if (!isError(compressed)) {
+      await compressed.write(getNextArchivePath(lastUpdateTime).path);
+    }
+    await tmp.remove();
   }
 
   // 一週間前のログファイルを削除
   const thresholdDate = dayjs().subtract(7, 'd');
-  const paths = await logDir.iter();
+  const paths = await logPath.iter();
   if (isError(paths)) return;
   for (const path of paths) {
     if (!path.path.endsWith(ARCHIVE_EXT)) continue;
@@ -98,37 +86,19 @@ async function archiveLog(logDir: Path) {
   }
 }
 
-export function getRootLogger(logDir: Path): {
-  logger: LoggerHierarchy;
-  archive: () => Promise<void>;
-} {
-  logDir.child(LATEST).writeTextSync('');
-
-  log4js.configure({
-    appenders: {
-      _out: {
-        type: 'stdout',
-        layout: { type: 'custom', max: 500 },
-      },
-      _file: {
-        type: 'file',
-        filename: logDir.child(LATEST).str(),
-        layout: { type: 'custom', max: 500 },
-      },
-      out: { type: 'logLevelFilter', appender: '_out', level: 'warn' },
-      file: { type: 'logLevelFilter', appender: '_file', level: 'trace' },
-    },
-    categories: {
-      default: { appenders: ['out', 'file'], level: 'trace' },
-    },
-  });
-
-  return { logger: getLoggerHierarchy(), archive: () => archiveLog(logDir) };
+function getNextArchivePath(time: Dayjs): Path {
+  let i = 0;
+  const prefix = time.format('YYYY-MM-DD-HH');
+  while (true) {
+    const path = logDir.child(`${prefix}-${i}${ARCHIVE_EXT}`);
+    if (!path.exists()) return path;
+    i += 1;
+  }
 }
 
 // export type loglevel = 'trace' | 'debug' | 'info' | 'warn' | 'error' | 'fatal'
 
-const loggerSymbol = Symbol();
+const CATEGORY = Symbol();
 
 class LoggerWrapper {
   private logger: log4js.Logger;
@@ -138,59 +108,148 @@ class LoggerWrapper {
     this.arg = arg;
   }
 
-  start(...message: any[]) {
-    this.logger.trace('start', this.arg, ...message);
-  }
-  success(...message: any[]) {
-    this.logger.info('success', this.arg, ...message);
-  }
-  fail(...message: any[]) {
-    this.logger.info('fail', this.arg, ...message);
-  }
-  trace(...message: any[]) {
-    this.logger.trace('trace', this.arg, ...message);
-  }
-  debug(...message: any[]) {
-    this.logger.debug('debug', this.arg, ...message);
-  }
-  info(...message: any[]) {
-    this.logger.info('info', this.arg, ...message);
-  }
-  warn(...message: any[]) {
-    this.logger.warn('warn', this.arg, ...message);
-  }
-  error(...message: any[]) {
-    this.logger.error('error', this.arg, ...message);
-  }
-  fatal(...message: any[]) {
-    this.logger.fatal('fatal', this.arg, ...message);
-  }
+  private log =
+    (
+      level:
+        | 'start'
+        | 'success'
+        | 'fail'
+        | 'trace'
+        | 'debug'
+        | 'info'
+        | 'warn'
+        | 'error'
+        | 'fatal'
+    ) =>
+    (...message: any[]) =>
+      this.logger[level](
+        applyOmission(this.arg),
+        simplifyArgs(...applyOmission(message))
+      ); // 伏字処理を施してログを吐く
+
+  // TODO: start, success, fail を削除
+  start = this.log('start');
+  success = this.log('success');
+  fail = this.log('fail');
+
+  trace = this.log('trace');
+  debug = this.log('debug');
+  info = this.log('info');
+  warn = this.log('warn');
+  error = this.log('error');
+  fatal = this.log('fatal');
+
+  // start(...message: any[]) {
+  //   this.logger.trace('start', this.arg, ...message);
+  // }
+  // success(...message: any[]) {
+  //   this.logger.info('success', this.arg, ...message);
+  // }
+  // fail(...message: any[]) {
+  //   this.logger.info('fail', this.arg, ...message);
+  // }
+  // trace(...message: any[]) {
+  //   this.logger.trace('trace', this.arg, ...message);
+  // }
+  // debug(...message: any[]) {
+  //   this.logger.debug('debug', this.arg, ...message);
+  // }
+  // info(...message: any[]) {
+  //   this.logger.info('info', this.arg, ...message);
+  // }
+  // warn(...message: any[]) {
+  //   this.logger.warn('warn', this.arg, ...message);
+  // }
+  // error(...message: any[]) {
+  //   this.logger.error('error', this.arg, ...message);
+  // }
+  // fatal(...message: any[]) {
+  //   this.logger.fatal('fatal', this.arg, ...message);
+  // }
 }
 
 export interface LoggerHierarchy extends Record<string, LoggerHierarchy> {
-  [loggerSymbol]: string | undefined;
-  (kwargs: object): LoggerWrapper;
+  [CATEGORY]: string | undefined;
+  /** ワールド名やサーバーid等,実行コンテクストを過不足なく提供するとよい */
+  (...args: any[]): LoggerWrapper;
 }
 
-function getLoggerHierarchy(category?: string | undefined) {
-  const childLogger = log4js.getLogger(category);
+const loggerHierarchies = InfinitMap.primitiveKeyStrongValue(
+  (category: string) => {
+    const logger = log4js.getLogger(category || undefined);
+    const loggerHierarchy: LoggerHierarchy = ((...args: any[]) => {
+      return new LoggerWrapper(logger, simplifyArgs(...args));
+    }) as LoggerHierarchy;
+    loggerHierarchy[CATEGORY] = category;
+    return new Proxy<LoggerHierarchy>(loggerHierarchy, handler);
+  }
+);
 
-  const loggerHierarchy: LoggerHierarchy = ((kwargs: object) =>
-    new LoggerWrapper(childLogger, kwargs)) as LoggerHierarchy;
+/**
+ * argsの個数に応じて戻り値が変わる
+ * - argsが0この場合 - undefined
+ * - argsが1この場合 - args[0]
+ * - argsが2この場合 - args
+ */
+function simplifyArgs(...args: any[]): any {
+  const params =
+    args.length === 0 ? undefined : args.length === 1 ? args[0] : args;
+  return params;
+}
 
-  loggerHierarchy[loggerSymbol] = category;
+type LogOmission = (
+  value: string,
+  path: (string | number)[]
+) => Failable<string>;
 
-  return new Proxy<LoggerHierarchy>(loggerHierarchy, handler);
+const omissions: Set<LogOmission> = new Set();
+
+/** オブジェクトに伏字を適用する */
+function applyOmission<T>(value: T, path: (string | number)[] = []): T {
+  switch (typeof value) {
+    case 'string':
+      let val: string = value;
+      for (const omission of omissions) {
+        const omitted = omission(val, path);
+        if (!isError(omitted)) val = omitted;
+      }
+      return val as T;
+    case 'object': {
+      if (value === null) return null as T;
+      if (Array.isArray(value)) {
+        return value.map((v, i) => applyOmission(v, [...path, i])) as T;
+      }
+      return Object.fromEntries(
+        Object.entries(value).map(([k, v]) => [
+          k,
+          applyOmission(v, [...path, k]),
+        ])
+      ) as T;
+    }
+    default:
+      return value;
+  }
 }
 
 const handler: ProxyHandler<LoggerHierarchy> = {
   get(target, subCategory: string) {
-    const category = target[loggerSymbol];
-    const newCategory =
-      category === undefined ? subCategory : `${category}.${subCategory}`;
-    return getLoggerHierarchy(newCategory);
+    const category = target[CATEGORY];
+    const newCategory = category ? `${category}.${subCategory}` : subCategory;
+    return loggerHierarchies.get(newCategory);
   },
 };
+
+/**
+ * 伏字ルールを追加
+ * @returns 伏字ルールを解除する
+ */
+export function addOmisstionRule(omisstionRule: LogOmission) {
+  omissions.add(omisstionRule);
+  return () => omissions.delete(omisstionRule);
+}
+
+/** ルート要素のロガー */
+export const rootLogger = loggerHierarchies.get('');
 
 /** In Source Testing */
 if (import.meta.vitest) {

--- a/src-electron/common/logger.ts
+++ b/src-electron/common/logger.ts
@@ -1,5 +1,6 @@
 import { randomInt } from 'crypto';
 import dayjs, { Dayjs } from 'dayjs';
+import { app } from 'electron';
 import * as fs from 'fs-extra';
 import log4js from 'log4js';
 import { c } from 'tar';
@@ -20,7 +21,8 @@ const logPaths = EXTs.map((ext) => logDir.child(`${LATEST}${ext}`));
 const beforeArchivePaths = EXTs.map((ext) => logDir.child(`${TMP_LOG}${ext}`));
 
 // LATASTの上書き前にアーカイブファイルを作成
-if (logPaths.every((path) => path.exists())) {
+// Testの時には下記のコードは実行しない
+if (app && logPaths.every((path) => path.exists())) {
   logPaths.forEach((path, idx) =>
     fs.copyFileSync(path.path, beforeArchivePaths[idx].path)
   );
@@ -365,6 +367,10 @@ if (import.meta.vitest) {
       // 伏字チェック
 
       const unsetRule = addOmisstionRule((v) => (v === 'invalid' ? '***' : v));
+      addOmisstionRule((v, p) => {
+        console.log(v, p);
+        return v;
+      });
 
       rootLogger().info('invalid');
       expect(

--- a/src-electron/common/logger.ts
+++ b/src-electron/common/logger.ts
@@ -134,7 +134,7 @@ log4js.configure({
     fileTruncate: {
       type: 'logLevelFilter',
       appender: '_fileTruncate',
-      level: 'trace',
+      level: 'debug',
     },
   },
   categories: {

--- a/src-electron/common/logger.ts
+++ b/src-electron/common/logger.ts
@@ -9,16 +9,13 @@ import { logDir } from '../source/const';
 import { Path } from '../util/binary/path';
 import { isError } from '../util/error/error';
 import { InfinitMap } from '../util/helper/infinitMap';
+import { isValidIP } from '../util/network/ip';
 
 const TIME_FORMAT = 'YYYY-MM-DD HH:mm:ss.SSS';
 const LATEST = 'latest';
 const EXTs = ['.log', '.truncate.log'];
 const TMP_LOG = `tmp_${randomInt(2 ** 31)}`;
 const ARCHIVE_EXT = '.log.tar.gz';
-const IPv4_REGEX =
-  /\b(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\b/;
-const IPv6_REGEX =
-  /((([0-9a-f]{1,4}:){7}([0-9a-f]{1,4}|:))|(([0-9a-f]{1,4}:){6}(:[0-9a-f]{1,4}|((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3})|:))|(([0-9a-f]{1,4}:){5}(((:[0-9a-f]{1,4}){1,2})|:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3})|:))|(([0-9a-f]{1,4}:){4}(((:[0-9a-f]{1,4}){1,3})|((:[0-9a-f]{1,4})?:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9a-f]{1,4}:){3}(((:[0-9a-f]{1,4}){1,4})|((:[0-9a-f]{1,4}){0,2}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9a-f]{1,4}:){2}(((:[0-9a-f]{1,4}){1,5})|((:[0-9a-f]{1,4}){0,3}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9a-f]{1,4}:){1}(((:[0-9a-f]{1,4}){1,6})|((:[0-9a-f]{1,4}){0,4}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(:(((:[0-9a-f]{1,4}){1,7})|((:[0-9a-f]{1,4}){0,5}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:)))(%.+)?\s*$/;
 
 fs.ensureDirSync(logDir.path);
 const logPaths = EXTs.map((ext) => logDir.child(`${LATEST}${ext}`));
@@ -265,8 +262,7 @@ type LogOmission = (value: string, path: (string | number)[]) => string;
 
 // 以下の伏字ルールを追加
 const omissions: Set<LogOmission> = new Set([
-  (v) => v.replace(IPv4_REGEX, ':IPv4:'),
-  (v) => v.replace(IPv6_REGEX, ':IPv6:'),
+  (v) => (isValidIP(v) ? ':IpAddress:' : v),
   (v, p) => (p[p.length - 1] === 'ngrokToken' ? ':NgrokToken:' : v),
 ]);
 
@@ -417,6 +413,22 @@ if (import.meta.vitest) {
         )
       ).toBe(true);
 
+      // 規定の省略ルール
+
+      rootLogger().info(['success', '127.0.0.1']);
+      expect(
+        await isMatchLogInLines(
+          '"lv":"INFO","on":"default","msg":["success",":IpAddress:"]'
+        )
+      ).toBe(true);
+
+      rootLogger().info({ ngrokToken: 'XXXXXX' });
+      expect(
+        await isMatchLogInLines(
+          '"lv":"INFO","on":"default","msg":{"ngrokToken":":NgrokToken:"}'
+        )
+      ).toBe(true);
+
       // アーカイブチェック
       const logPaths = await logDir.iter();
       expect(isError(logPaths)).toBe(false);
@@ -505,30 +517,5 @@ if (import.meta.vitest) {
     test.each(testCases)('eachTruncateLog', ({ sourceParam, expectStr }) => {
       expect(truncateValue(sourceParam)).toBe(expectStr);
     });
-  });
-
-  test('ip omission', async () => {
-    const ipv4Samples = [
-      '192.168.1.1',
-      '10.0.0.1',
-      '172.16.254.1',
-      '8.8.8.8',
-      '127.0.0.1',
-    ];
-    const ipv6Samples = [
-      '2001:db8:3333:4444:5555:6666:7777:8888',
-      '2001:db8::',
-      '::1',
-      '2001:db8::1234:56',
-      'fe80::394:a9b4:14d:7993',
-      'fe80::1',
-    ];
-
-    for (const ip4 of ipv4Samples) {
-      expect(applyOmission(ip4)).toBe(':IPv4:');
-    }
-    for (const ip6 of ipv6Samples) {
-      expect(applyOmission(ip6)).toBe(':IPv6:');
-    }
   });
 }

--- a/src-electron/core/logger.ts
+++ b/src-electron/core/logger.ts
@@ -1,9 +1,0 @@
-import { getRootLogger, rootLogger } from '../common/logger';
-import { onQuit } from '../lifecycle/lifecycle';
-import { logDir } from '../source/const';
-
-const { logger, archive } = getRootLogger(logDir);
-
-onQuit(archive, true);
-
-export const rootLoggerHierarchy = rootLogger;

--- a/src-electron/core/logger.ts
+++ b/src-electron/core/logger.ts
@@ -1,9 +1,9 @@
-import { getRootLogger } from '../common/logger';
+import { getRootLogger, rootLogger } from '../common/logger';
 import { onQuit } from '../lifecycle/lifecycle';
-import { logPath } from '../source/const';
+import { logDir } from '../source/const';
 
-const { logger, archive } = getRootLogger(logPath);
+const { logger, archive } = getRootLogger(logDir);
 
 onQuit(archive, true);
 
-export const rootLoggerHierarchy = logger;
+export const rootLoggerHierarchy = rootLogger;

--- a/src-electron/lifecycle/lifecycle.ts
+++ b/src-electron/lifecycle/lifecycle.ts
@@ -3,7 +3,7 @@ import { createAppEvent } from './event';
 /** electronのwillQuitイベント(すべてのwindowが閉じた後の処理)で発火されるイベント */
 export const onQuit = createAppEvent();
 
-/** electronのwillQuitイベント(すべてのwindowが閉じた後の処理)で発火されるイベント */
+/** フロントエンドからWindowの生成が完了した通知が来た際に発火されるイベント */
 export const onReadyWindow = createAppEvent();
 
 /**

--- a/src-electron/schema/static.ts
+++ b/src-electron/schema/static.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import {
   DATAPACK_CACHE_PATH,
-  logPath,
+  logDir,
   MOD_CACHE_PATH,
   PLUGIN_CACHE_PATH,
 } from '../source/const';
@@ -39,7 +39,7 @@ export const StaticResouce = z.object({
   minecraftColors: MinecraftColors,
   paths: z
     .object({
-      log: z.string().default(logPath.str()),
+      log: z.string().default(logDir.str()),
       cache: z
         .object({
           datapack: z.string().default(DATAPACK_CACHE_PATH.str()),

--- a/src-electron/source/const.ts
+++ b/src-electron/source/const.ts
@@ -15,7 +15,9 @@ const userDataPath = (
 export const mainPath = userDataPath;
 
 export const cachePath = mainPath.child('serverstarter/cache');
-export const logDir = mainPath.child('serverstarter/log');
+export const logDir = !app
+  ? new Path('src-electron/common/work/log')
+  : mainPath.child('serverstarter/log');
 export const tempPath = mainPath.child('serverstarter/temp');
 
 export const settingPath = mainPath.child('serverstarter/settings.ssconfig');

--- a/src-electron/source/const.ts
+++ b/src-electron/source/const.ts
@@ -15,7 +15,7 @@ const userDataPath = (
 export const mainPath = userDataPath;
 
 export const cachePath = mainPath.child('serverstarter/cache');
-export const logPath = mainPath.child('serverstarter/log');
+export const logDir = mainPath.child('serverstarter/log');
 export const tempPath = mainPath.child('serverstarter/temp');
 
 export const settingPath = mainPath.child('serverstarter/settings.ssconfig');

--- a/src-electron/source/server/setup/memory.ts
+++ b/src-electron/source/server/setup/memory.ts
@@ -1,5 +1,5 @@
+import { rootLogger } from 'app/src-electron/common/logger';
 import { MemorySettings } from 'app/src-electron/schema/memory';
-import { rootLoggerHierarchy } from '../../../core/logger';
 import { getSystemSettings } from '../../stores/system';
 
 export async function getMemoryArguments(memory: MemorySettings | undefined) {
@@ -34,7 +34,7 @@ export async function getMemoryArguments(memory: MemorySettings | undefined) {
       memorystr = `${memorySize}T`;
       break;
     default:
-      rootLoggerHierarchy.server
+      rootLogger.server
         .setMamoryAmount(memory)
         .error(`unknown unit ${memory.unit}`);
       return getMemoryArguments(defaultMemory);

--- a/src-electron/updater/updater.ts
+++ b/src-electron/updater/updater.ts
@@ -32,7 +32,7 @@ async function checkUpdate(pat: string | undefined) {
 export async function update() {
   const logger = rootLogger.update({});
   logger.info('start');
-  logger.trace('system version', await getSystemVersion());
+  logger.info('system version', await getSystemVersion());
 
   // 環境変数SERVERSTARTER_MODEが"debug"だった場合は環境変数SERVERSTARTER_TOKENからgitのPATを取得
   const PAT =

--- a/src-electron/updater/updater.ts
+++ b/src-electron/updater/updater.ts
@@ -1,4 +1,4 @@
-import { rootLoggerHierarchy } from '../core/logger';
+import { rootLogger } from '../common/logger';
 import { getSystemSettings, setSystemSettings } from '../source/stores/system';
 import { isError } from '../util/error/error';
 import { osPlatform } from '../util/os/os';
@@ -30,8 +30,9 @@ async function checkUpdate(pat: string | undefined) {
  * リモートのバージョンはgithubのリリース情報のtag_nameを参照
  */
 export async function update() {
-  const logger = rootLoggerHierarchy.update({});
-  logger.start(getSystemVersion());
+  const logger = rootLogger.update({});
+  logger.info('start');
+  logger.trace('system version', getSystemVersion())
 
   // 環境変数SERVERSTARTER_MODEが"debug"だった場合は環境変数SERVERSTARTER_TOKENからgitのPATを取得
   const PAT =
@@ -70,5 +71,5 @@ export async function update() {
       break;
   }
 
-  logger.success();
+  logger.info('success');
 }

--- a/src-electron/updater/updater.ts
+++ b/src-electron/updater/updater.ts
@@ -41,11 +41,17 @@ export async function update() {
       : undefined;
 
   const update = await checkUpdate(PAT);
+
+  if (update === false) {
+    logger.error(update);
+    return;
+  }
+
+  if (isError(update)) {
+    logger.error(update);
+    return;
+  }
   logger.info(update);
-
-  if (update === false) return;
-
-  if (isError(update)) return;
 
   // 環境変数DEBUGGING==true(yarn devで起動した場合)実際のアップデート処理は行わない
   if (process.env.DEBUGGING) return;

--- a/src-electron/updater/updater.ts
+++ b/src-electron/updater/updater.ts
@@ -32,7 +32,7 @@ async function checkUpdate(pat: string | undefined) {
 export async function update() {
   const logger = rootLogger.update({});
   logger.info('start');
-  logger.trace('system version', getSystemVersion());
+  logger.trace('system version', await getSystemVersion());
 
   // 環境変数SERVERSTARTER_MODEが"debug"だった場合は環境変数SERVERSTARTER_TOKENからgitのPATを取得
   const PAT =

--- a/src-electron/util/binary/bytesData.ts
+++ b/src-electron/util/binary/bytesData.ts
@@ -407,6 +407,6 @@ if (import.meta.vitest) {
       if (isError(bytes)) return;
 
       await expect(bytes.hash('sha1')).resolves.toBe(jarHash);
-    });
+    }, 60 * 1000);
   });
 }

--- a/src-electron/util/binary/bytesData.ts
+++ b/src-electron/util/binary/bytesData.ts
@@ -33,7 +33,7 @@ export class BytesData {
     headers?: { [key in string]: string }
   ): Promise<Failable<BytesData>> {
     const logger = loggers().fromURL({ url, hash });
-    logger.info('start');
+    logger.trace('start');
 
     try {
       const res = await fetch(url, { headers });
@@ -49,12 +49,12 @@ export class BytesData {
       const result = new BytesData(Buffer.from(buffer));
 
       if (hash === undefined) {
-        logger.info('success');
+        logger.trace('success');
         return result;
       }
       const calcHash = await result.hash(hash.type);
       if (hash.value === calcHash) {
-        logger.info('success');
+        logger.trace('success');
         return result;
       }
 
@@ -80,19 +80,19 @@ export class BytesData {
       path: path.path,
       hash,
     });
-    logger.info('start');
+    logger.trace('start');
 
     try {
       const buffer = await promises.readFile(path.path);
       const data = new BytesData(buffer);
       if (hash === undefined) {
-        logger.info('success');
+        logger.trace('success');
         return data;
       }
 
       const calcHash = await data.hash(hash.type);
       if (hash.value === calcHash) {
-        logger.info('success');
+        logger.trace('success');
         return data;
       }
       const msg = `hash value unmatch expected: ${hash} calculated: ${calcHash}`;

--- a/src-electron/util/binary/path.ts
+++ b/src-electron/util/binary/path.ts
@@ -291,7 +291,7 @@ export class Path {
   }
 
   moveTo = exclusive(this._moveTo);
-  private async _moveTo(target: Path): Promise<Failable<void>> {
+  private async _moveTo(target: Path, options?: fs.MoveOptions): Promise<Failable<void>> {
     if (!this.exists()) return;
     await target.parent().mkdir(true);
     const isSuccessRemove = await target._remove();
@@ -311,7 +311,7 @@ export class Path {
           await recursiveMove(child, target.child(child.basename()));
         });
       } else {
-        await fs.move(path.path, target.path);
+        await fs.move(path.path, target.path, options);
       }
     }
     const res = await recursiveMove(this, target);

--- a/src-electron/util/binary/path.ts
+++ b/src-electron/util/binary/path.ts
@@ -291,7 +291,10 @@ export class Path {
   }
 
   moveTo = exclusive(this._moveTo);
-  private async _moveTo(target: Path, options?: fs.MoveOptions): Promise<Failable<void>> {
+  private async _moveTo(
+    target: Path,
+    options?: fs.MoveOptions
+  ): Promise<Failable<void>> {
     if (!this.exists()) return;
     await target.parent().mkdir(true);
     const isSuccessRemove = await target._remove();
@@ -311,7 +314,14 @@ export class Path {
           await recursiveMove(child, target.child(child.basename()));
         });
       } else {
-        await fs.move(path.path, target.path, options);
+        try {
+          await fs.move(path.path, target.path, options);
+        } catch {
+          return errorMessage.data.path.moveFailed({
+            type: 'file',
+            path: path.path,
+          });
+        }
       }
     }
     const res = await recursiveMove(this, target);

--- a/src-electron/util/error/schema/data.ts
+++ b/src-electron/util/error/schema/data.ts
@@ -64,6 +64,9 @@ export type DataErrors = {
     // ファイルまたはディレクトリの削除に失敗
     deletionFailed: PathErrorContent;
 
+    // ファイルまたはディレクトリの移動に失敗
+    moveFailed: PathErrorContent;
+
     // ファイル選択ウィンドウがキャンセルされた場合
     dialogCanceled: ErrorMessageContent;
 

--- a/src-electron/util/network/ip.ts
+++ b/src-electron/util/network/ip.ts
@@ -1,3 +1,4 @@
+import { z } from 'zod';
 import { Failable } from '../../schema/error';
 import { BytesData } from '../binary/bytesData';
 import { errorMessage } from '../error/construct';
@@ -42,4 +43,41 @@ export async function getGlobalIP(): Promise<Failable<string>> {
   }
 
   return errorMessage.core.failGetGlobalIP();
+}
+
+/** 指定したIPアドレスが有効かどうか */
+export function isValidIP(ip: string): boolean {
+  const parser = z.string().ip();
+  const result = parser.safeParse(ip);
+  return result.success;
+}
+
+/** In Source Testing */
+if (import.meta.vitest) {
+  const { test, expect } = import.meta.vitest;
+
+  test('ip validation', async () => {
+    const ipv4Samples = [
+      '192.168.1.1',
+      '10.0.0.1',
+      '172.16.254.1',
+      '8.8.8.8',
+      '127.0.0.1',
+    ];
+    const ipv6Samples = [
+      '2001:db8:3333:4444:5555:6666:7777:8888',
+      '2001:db8::',
+      '::1',
+      '2001:db8::1234:56',
+      'fe80::394:a9b4:14d:7993',
+      'fe80::1',
+    ];
+
+    for (const ip4 of ipv4Samples) {
+      expect(isValidIP(ip4)).toBe(true);
+    }
+    for (const ip6 of ipv6Samples) {
+      expect(isValidIP(ip6)).toBe(true);
+    }
+  });
 }

--- a/src-electron/util/utilLogger.ts
+++ b/src-electron/util/utilLogger.ts
@@ -1,3 +1,3 @@
-import { rootLoggerHierarchy } from '../core/logger';
+import { rootLogger } from '../common/logger';
 
-export const utilLoggers = rootLoggerHierarchy.util;
+export const utilLoggers = () => rootLogger.util;

--- a/src/i18n/en-US/Other/error.ts
+++ b/src/i18n/en-US/Other/error.ts
@@ -115,6 +115,10 @@ export const enUSError: MessageSchema['error'] = {
         title: 'Failed to delete {type}',
         desc: 'Failed to delete {path}',
       },
+      moveFailed: {
+        title: 'Failed to move {type}',
+        desc: 'Failed to move {path}',
+      },
       dialogCanceled: {
         title: 'Window to select file is cancelled',
       },

--- a/src/i18n/ja/Other/error.ts
+++ b/src/i18n/ja/Other/error.ts
@@ -117,6 +117,10 @@ export const jaError: ErrorTranslationTypes & ErrorDialogTitles = {
         title: '{type}の削除に失敗しました',
         desc: '{path}の削除ができませんでした',
       },
+      moveFailed: {
+        title: '{type}の移動に失敗しました',
+        desc: '{path}の移動ができませんでした',
+      },
       dialogCanceled: {
         title: 'ファイル選択ウィンドウがキャンセルされました',
       },


### PR DESCRIPTION
# 概要

V2実装によるLoggerを本番環境に移築

Start, SuccessのようなLog4jsがサポートしない形式のログを廃止し，標準的なログ出力に変更

伏字にも対応可能なスキーマを導入し，以下の要素については伏字が適用される
- IPアドレス（v4 / v6）
- Ngrokトークン

現状のログファイル（`latest.log`）は内容が膨らみ過ぎて見にくいものになっていたため，見やすい抜粋版（`latest.truncate.log`）を同時生成する仕様に変更


## そのほかの変更

- Logアーカイブの生成タイミングをプログラム終了時からプログラム開始時に変更
（ログを最も確認したい異常終了時において，アーカイブがプログラム終了時の場合，異常終了のログが次の実行ログで上書きされてしまい，確認手段が失われる問題に対応するため）
- `path.moveTo()`において，エラーハンドリングが抜けていた問題を修正
- `logPath`をV2実装に合わせて`logDir`に変数名を変更
- `path.str()`のような非推奨実装を一部修正