### PR TITLE
V2のRuntime実装を導入

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@ngrok/ngrok": "^0.9.1",
     "@quasar/extras": "^1.16.4",
+    "axios": "^1.9.0",
     "browser-image-compression": "^2.0.2",
     "cheerio": "^1.0.0-rc.12",
     "cropperjs": "^1.5.13",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "jszip": "^3.10.1",
     "log4js": "^6.9.1",
     "mousetrap": "^1.6.5",
+    "p-queue": "^8.1.0",
     "pinia": "^2.1.4",
     "prismarine-nbt": "^2.2.1",
     "quasar": "^2.12.2",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
   "dependencies": {
     "@ngrok/ngrok": "^0.9.1",
     "@quasar/extras": "^1.16.4",
-    "axios": "^1.9.0",
     "browser-image-compression": "^2.0.2",
     "cheerio": "^1.0.0-rc.12",
     "cropperjs": "^1.5.13",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "jszip": "^3.10.1",
     "log4js": "^6.9.1",
     "mousetrap": "^1.6.5",
-    "p-queue": "^8.1.0",
     "pinia": "^2.1.4",
     "prismarine-nbt": "^2.2.1",
     "quasar": "^2.12.2",

--- a/src-electron/core/setup.ts
+++ b/src-electron/core/setup.ts
@@ -1,0 +1,18 @@
+// import { datapackSourcePath, serverSourcePath } from '../common/paths';
+import { runtimePath } from '../source/const';
+import { getUniversalConfig } from '../source/runtime/getUnivConfig';
+import { RuntimeContainer } from '../source/runtime/runtime';
+
+// import { DatapackContainer } from '../source/datapack/datapack';
+// import { ServerContainer } from '../source/server/server';
+
+/**
+ * coreが必要とするsourceの初期化を行う
+ */
+
+// export const datapackContainer = new DatapackContainer(datapackSourcePath);
+// export const serverContainer = new ServerContainer(serverSourcePath);
+export const runtimeContainer = new RuntimeContainer(
+  runtimePath,
+  getUniversalConfig
+);

--- a/src-electron/schema/manifest.ts
+++ b/src-electron/schema/manifest.ts
@@ -1,0 +1,37 @@
+import { z } from 'zod';
+
+export const ManifestDirectory = z.object({
+  type: z.literal('directory'),
+});
+export type ManifestDirectory = z.infer<typeof ManifestDirectory>;
+
+export const ManifestLink = z.object({
+  type: z.literal('link'),
+  target: z.string(),
+});
+export type ManifestLink = z.infer<typeof ManifestLink>;
+
+export const ManifestFile = z.object({
+  type: z.literal('file'),
+  executable: z.boolean(),
+  downloads: z.object({
+    raw: z.object({
+      sha1: z.string(),
+      size: z.number(),
+      url: z.string(),
+    }),
+  }),
+});
+export type ManifestFile = z.infer<typeof ManifestFile>;
+
+export const ManifestContent = z.object({
+  files: z.record(
+    z.string(),
+    z.discriminatedUnion('type', [
+      ManifestDirectory,
+      ManifestLink,
+      ManifestFile,
+    ])
+  ),
+});
+export type ManifestContent = z.infer<typeof ManifestContent>;

--- a/src-electron/schema/runtime.ts
+++ b/src-electron/schema/runtime.ts
@@ -3,6 +3,9 @@ import { z } from 'zod';
 export const JavaMajorVersion = z.number().brand('JavaMajorVersion');
 export type JavaMajorVersion = z.infer<typeof JavaMajorVersion>;
 
+/**
+ * MinecraftがサポートするJavaのバージョンリスト
+ */
 export const JavaComponent = z.enum([
   'java-runtime-alpha',
   'java-runtime-beta',
@@ -51,3 +54,41 @@ export const RuntimeSettings = z.union([
   z.object({ memory: z.tuple([z.number(), z.enum(['MB', 'GB', 'TB'])]) }),
 ]);
 export type RuntimeSettings = z.infer<typeof RuntimeSettings>;
+
+// Manifest
+const McRuntimeVerManifest = z.object({
+  manifest: z.object({
+    sha1: z.string(),
+    size: z.number(),
+    url: z.string(),
+  }),
+});
+const McOsManifest = z.record(
+  z.string(),
+  z.array(McRuntimeVerManifest).optional()
+);
+export const McRuntimeManifest = z.object({
+  linux: McOsManifest,
+  'mac-os': McOsManifest,
+  'mac-os-arm64': McOsManifest,
+  'windows-x64': McOsManifest,
+  'windows-arm64': McOsManifest,
+});
+export type McRuntimeManifest = z.infer<typeof McRuntimeManifest>;
+
+// Correttoは未実装
+export const CorrettoRuntimeManifest = z.object({});
+export type CorrettoRuntimeManifest = z.infer<typeof CorrettoRuntimeManifest>;
+
+/**
+ * 各Runtimeの取得に使用するManifestの型定義
+ */
+const AllRuntimeManifests = z.object({
+  minecraft: McRuntimeManifest,
+  corretto: CorrettoRuntimeManifest,
+});
+export type AllRuntimeManifests = z.infer<typeof AllRuntimeManifests>;
+
+type Keys<T> = keyof T;
+type Values<T extends Record<string, z.ZodType>> = z.infer<T[Keys<T>]>;
+export type RuntimeManifest = Values<typeof AllRuntimeManifests.shape>;

--- a/src-electron/schema/runtime.ts
+++ b/src-electron/schema/runtime.ts
@@ -1,0 +1,44 @@
+import { z } from 'zod';
+
+export const JavaMajorVersion = z.number().brand('JavaMajorVersion');
+export type JavaMajorVersion = z.infer<typeof JavaMajorVersion>;
+
+// minecraftのデフォルトのランタイム
+export const MinecraftRuntime = z.object({
+  type: z.literal('minecraft'),
+  /**
+   * 'jre-legacy'
+   * 'java-runtime-alpha'
+   * 'java-runtime-beta'
+   * 'java-runtime-gamma'
+   * 'java-runtime-delta';
+   */
+  version: z.string(),
+});
+export type MinecraftRuntime = z.infer<typeof MinecraftRuntime>;
+
+// バージョンだけを指定するランタイム
+// 実際は MinecraftRuntime か CorrettoRuntime かになる
+export type UniversalRuntime = {
+  type: 'universal';
+  majorVersion: JavaMajorVersion;
+};
+
+/**
+ * Amazon Coretto で提供されているランタイム (未使用)
+ *
+ * https://aws.amazon.com/jp/corretto
+ */
+export type CorrettoRuntime = {
+  type: 'corretto';
+  majorVersion: JavaMajorVersion;
+};
+
+export type Runtime = MinecraftRuntime | UniversalRuntime; // | CorrettoRuntime
+
+/** メモリ等ランタイムの設定 */
+export const RuntimeSettings = z.union([
+  z.object({ jvmarg: z.string() }),
+  z.object({ memory: z.tuple([z.number(), z.enum(['MB', 'GB', 'TB'])]) }),
+]);
+export type RuntimeSettings = z.infer<typeof RuntimeSettings>;

--- a/src-electron/schema/runtime.ts
+++ b/src-electron/schema/runtime.ts
@@ -3,6 +3,15 @@ import { z } from 'zod';
 export const JavaMajorVersion = z.number().brand('JavaMajorVersion');
 export type JavaMajorVersion = z.infer<typeof JavaMajorVersion>;
 
+export const JavaComponent = z.enum([
+  'java-runtime-alpha',
+  'java-runtime-beta',
+  'java-runtime-gamma',
+  'java-runtime-delta',
+  'jre-legacy',
+]);
+export type JavaComponent = z.infer<typeof JavaComponent>;
+
 // minecraftのデフォルトのランタイム
 export const MinecraftRuntime = z.object({
   type: z.literal('minecraft'),
@@ -13,7 +22,7 @@ export const MinecraftRuntime = z.object({
    * 'java-runtime-gamma'
    * 'java-runtime-delta';
    */
-  version: z.string(),
+  version: JavaComponent,
 });
 export type MinecraftRuntime = z.infer<typeof MinecraftRuntime>;
 

--- a/src-electron/schema/runtime.ts
+++ b/src-electron/schema/runtime.ts
@@ -62,6 +62,10 @@ const McRuntimeVerManifest = z.object({
     size: z.number(),
     url: z.string(),
   }),
+  version: z.object({
+    name: z.string(),
+    released: z.string(),
+  }),
 });
 const McOsManifest = z.record(
   z.string(),

--- a/src-electron/source/const.ts
+++ b/src-electron/source/const.ts
@@ -25,10 +25,6 @@ export const settingPath = mainPath.child('serverstarter/settings.ssconfig');
 export const runtimePath = cachePath.child('bin/runtime');
 export const versionsCachePath = cachePath.child('versions');
 
-export const versionManifestPath = versionsCachePath.child(
-  'vanilla/version_manifest_v2.json'
-);
-
 export const ADDITIONALS_CACHE_PATH = cachePath.child('additionals');
 export const DATAPACK_CACHE_PATH = ADDITIONALS_CACHE_PATH.child('datapacks');
 export const PLUGIN_CACHE_PATH = ADDITIONALS_CACHE_PATH.child('plugins');

--- a/src-electron/source/runtime/base.ts
+++ b/src-electron/source/runtime/base.ts
@@ -1,4 +1,7 @@
 import { z } from 'zod';
+import { sourceLoggers } from '../sourceLogger';
+
+export const runtimeLoggers = () => sourceLoggers().runtime
 
 export const RuntimeMeta = z.object({
   /** アンインストール時にこのパスを丸ごと消せばOK */

--- a/src-electron/source/runtime/base.ts
+++ b/src-electron/source/runtime/base.ts
@@ -1,9 +1,4 @@
 import { z } from 'zod';
-import { GroupProgressor } from 'app/src-electron/common/progress';
-import { Failable } from 'app/src-electron/schema/error';
-import { OsPlatform } from 'app/src-electron/schema/os';
-import { Runtime } from 'app/src-electron/schema/runtime';
-import { Path } from 'app/src-electron/util/binary/path';
 
 export const RuntimeMeta = z.object({
   /** アンインストール時にこのパスを丸ごと消せばOK */
@@ -19,12 +14,3 @@ export const RuntimeMeta = z.object({
   java: z.object({ path: z.string(), sha1: z.string() }),
 });
 export type RuntimeMeta = z.infer<typeof RuntimeMeta>;
-
-export type RuntimeInstaller<R extends Runtime> = {
-  install(
-    installPath: Path,
-    runtime: R,
-    osPlatform: OsPlatform,
-    progress?: GroupProgressor
-  ): Promise<Failable<RuntimeMeta>>;
-};

--- a/src-electron/source/runtime/base.ts
+++ b/src-electron/source/runtime/base.ts
@@ -1,0 +1,36 @@
+import { z } from 'zod';
+import { Failable } from 'app/src-electron/schema/error';
+import { OsPlatform } from 'app/src-electron/schema/os';
+import { Runtime } from 'app/src-electron/schema/runtime';
+import { Path } from 'app/src-electron/util/binary/path';
+
+export const RuntimeMeta = z.object({
+  /** アンインストール時にこのパスを丸ごと消せばOK */
+  base: z.object({
+    /** ServerStarterの実行パスからの相対パス or 絶対パス */
+    path: z.string(),
+  }),
+  javaw: z.object({
+    /** ServerStarterの実行パスからの相対パス or 絶対パス */
+    path: z.string(),
+    sha1: z.string(),
+  }),
+  java: z.object({ path: z.string(), sha1: z.string() }),
+});
+export type RuntimeMeta = z.infer<typeof RuntimeMeta>;
+
+export type RuntimeInstaller<R extends Runtime> = {
+  install(
+    installPath: Path,
+    runtime: R,
+    osPlatform: OsPlatform
+  ): Promise<Failable<RuntimeMeta>>;
+
+  /** 各ランタイムのインストール先のパスを返す */
+  getInstallPath(
+    /** cache/runtime/bin/[RuntimeType] */
+    installBasePath: Path,
+    runtime: R,
+    osPlatform: OsPlatform
+  ): Path;
+};

--- a/src-electron/source/runtime/base.ts
+++ b/src-electron/source/runtime/base.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { GroupProgressor } from 'app/src-electron/common/progress';
 import { Failable } from 'app/src-electron/schema/error';
 import { OsPlatform } from 'app/src-electron/schema/os';
 import { Runtime } from 'app/src-electron/schema/runtime';
@@ -23,6 +24,7 @@ export type RuntimeInstaller<R extends Runtime> = {
   install(
     installPath: Path,
     runtime: R,
-    osPlatform: OsPlatform
+    osPlatform: OsPlatform,
+    progress?: GroupProgressor
   ): Promise<Failable<RuntimeMeta>>;
 };

--- a/src-electron/source/runtime/base.ts
+++ b/src-electron/source/runtime/base.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import { sourceLoggers } from '../sourceLogger';
 
-export const runtimeLoggers = () => sourceLoggers().runtime
+export const runtimeLoggers = () => sourceLoggers().runtime;
 
 export const RuntimeMeta = z.object({
   /** アンインストール時にこのパスを丸ごと消せばOK */

--- a/src-electron/source/runtime/base.ts
+++ b/src-electron/source/runtime/base.ts
@@ -25,12 +25,4 @@ export type RuntimeInstaller<R extends Runtime> = {
     runtime: R,
     osPlatform: OsPlatform
   ): Promise<Failable<RuntimeMeta>>;
-
-  /** 各ランタイムのインストール先のパスを返す */
-  getInstallPath(
-    /** cache/runtime/bin/[RuntimeType] */
-    installBasePath: Path,
-    runtime: R,
-    osPlatform: OsPlatform
-  ): Path;
 };

--- a/src-electron/source/runtime/getUnivConfig.ts
+++ b/src-electron/source/runtime/getUnivConfig.ts
@@ -1,0 +1,138 @@
+import { z } from 'zod';
+import { Failable } from 'app/src-electron/schema/error';
+import { OsPlatform } from 'app/src-electron/schema/os';
+import {
+  JavaComponent,
+  JavaMajorVersion,
+  Runtime,
+  UniversalRuntime,
+} from 'app/src-electron/schema/runtime';
+import { errorMessage } from 'app/src-electron/util/error/construct';
+
+// betaとgammaはメジャーバージョンが共に17のため，より新しいgammaを優先する
+const McTargetComponent = JavaComponent.exclude(['java-runtime-beta']);
+type McTargetComponent = z.infer<typeof McTargetComponent>;
+
+// minecraft のランタイムに基づいてコンポーネント名を返却する
+const McConfig = z.record(OsPlatform, z.record(z.number(), McTargetComponent));
+type McConfig = z.infer<typeof McConfig>;
+
+// debian, redhatはlinuxから取得
+const mcConfig: McConfig = {
+  debian: {
+    16: 'java-runtime-alpha',
+    21: 'java-runtime-delta',
+    17: 'java-runtime-gamma',
+    8: 'jre-legacy',
+  },
+  redhat: {
+    16: 'java-runtime-alpha',
+    21: 'java-runtime-delta',
+    17: 'java-runtime-gamma',
+    8: 'jre-legacy',
+  },
+  'mac-os': {
+    16: 'java-runtime-alpha',
+    17: 'java-runtime-gamma',
+    21: 'java-runtime-delta',
+    8: 'jre-legacy',
+  },
+  'mac-os-arm64': {
+    21: 'java-runtime-delta',
+    17: 'java-runtime-gamma',
+  },
+  'windows-x64': {
+    16: 'java-runtime-alpha',
+    17: 'java-runtime-gamma',
+    21: 'java-runtime-delta',
+    8: 'jre-legacy',
+  },
+};
+
+/**
+ * Java17のような一般バージョン番号から「'java-runtime-gamma'」のようなコンポーネント名を返す
+ *
+ * `majorVersion`が指定されていない場合は、最新のランタイムを返す
+ *
+ * TODO: OuterResourceからの取得に差替える
+ * TODO: MinecraftランタイムからCorrettoに差替える（フォールバックにする？）
+ */
+export function getUniversalConfig(
+  osPlatform: OsPlatform,
+  majorVersion?: JavaMajorVersion
+): Promise<Failable<Exclude<Runtime, UniversalRuntime>>> {
+  let version;
+  if (majorVersion) {
+    version = majorVersion;
+  } else {
+    version = Math.max(
+      ...Object.keys(mcConfig[osPlatform] ?? { 0: 'undefined' }).map(Number)
+    );
+  }
+
+  const runtimeComponentName = mcConfig[osPlatform]?.[version];
+  if (runtimeComponentName) {
+    return Promise.resolve({
+      type: 'minecraft',
+      version: runtimeComponentName,
+    });
+  } else {
+    return Promise.resolve(
+      errorMessage.core.runtime.installFailed({
+        runtimeType: 'universal',
+        targetOs: osPlatform,
+        version: version.toString(),
+      })
+    );
+  }
+}
+
+/** In Source Testing */
+if (import.meta.vitest) {
+  const { test, expect } = import.meta.vitest;
+  test('check runtime universal versions', async () => {
+    const { BytesData } = await import('../../util/binary/bytesData');
+    const { isError } = await import('../../util/error/error');
+    const { fromEntries } = await import('../../util/obj/obj');
+    const { McRuntimeManifest } = await import('../../schema/runtime');
+
+    const targetUrl =
+      'https://launchermeta.mojang.com/v1/products/java-runtime/2ec0cc96c44e5a76b9c8b7c39df7210883d12871/all.json';
+
+    // URLの内容を取得
+    const targetManifestBytes = await BytesData.fromURL(targetUrl);
+    expect(isError(targetManifestBytes)).toBeFalsy();
+    if (isError(targetManifestBytes)) return targetManifestBytes;
+    const manifestJson = await targetManifestBytes.json(McRuntimeManifest);
+    expect(isError(manifestJson)).toBeFalsy();
+    if (isError(manifestJson)) return manifestJson;
+
+    // 検証用データに整形
+    const cleanConfig = (obj: Record<string, any>) => {
+      const runtimeComponentName = Object.keys(obj).filter(
+        (k) =>
+          McTargetComponent.safeParse(k).success && (obj[k]?.length ?? 0 > 0)
+      );
+      return fromEntries(
+        runtimeComponentName.map((n) => [
+          obj[n]?.[0].version.name?.match(/^(\d+)/)?.[1] ?? 'undefined',
+          n,
+        ])
+      );
+    };
+    const linuxConfig = cleanConfig(manifestJson.linux);
+    const macConfig = cleanConfig(manifestJson['mac-os']);
+    const mac64Config = cleanConfig(manifestJson['mac-os-arm64']);
+    const winConfig = cleanConfig(manifestJson['windows-x64']);
+
+    // システム内で利用しているデータが最新か確認する
+    // 最新でない場合はここのテストで失敗するため，失敗内容に合わせて上記ハードコードを修正
+    expect({
+      debian: linuxConfig,
+      redhat: linuxConfig,
+      'mac-os': macConfig,
+      'mac-os-arm64': mac64Config,
+      'windows-x64': winConfig,
+    }).toEqual(mcConfig);
+  });
+}

--- a/src-electron/source/runtime/getUnivConfig.ts
+++ b/src-electron/source/runtime/getUnivConfig.ts
@@ -90,6 +90,29 @@ export function getUniversalConfig(
 /** In Source Testing */
 if (import.meta.vitest) {
   const { test, expect } = import.meta.vitest;
+  test('getUniversalConfig', async () => {
+    const { isError } = await import('../../util/error/error');
+
+    // get Java17
+    const runtime1 = await getUniversalConfig(
+      'windows-x64',
+      JavaMajorVersion.parse(17)
+    );
+    expect(isError(runtime1)).toBeFalsy();
+    expect(runtime1).toEqual({
+      type: 'minecraft',
+      version: 'java-runtime-gamma',
+    });
+
+    // get latest Java
+    const runtime2 = await getUniversalConfig('windows-x64');
+    expect(isError(runtime2)).toBeFalsy();
+    expect(runtime2).toEqual({
+      type: 'minecraft',
+      version: 'java-runtime-delta',
+    });
+  });
+
   test('check runtime universal versions', async () => {
     const { BytesData } = await import('../../util/binary/bytesData');
     const { isError } = await import('../../util/error/error');

--- a/src-electron/source/runtime/manifest.ts
+++ b/src-electron/source/runtime/manifest.ts
@@ -199,6 +199,8 @@ export abstract class JavaRuntimeInstaller<
     if (isError(extractRes)) {
       logger.error('Extract files from manifest failed', extractRes);
       return errorMessage.core.runtime.installFailed({
+        runtimeType: runtime.type,
+        targetOs: osPlatform,
         version: this.getRuntimeVersion(runtime),
       });
     }

--- a/src-electron/source/runtime/manifest.ts
+++ b/src-electron/source/runtime/manifest.ts
@@ -1,67 +1,353 @@
+/**
+ * Runtimeを生成するためのファクトリー
+ *
+ * Runtimeに関する情報（＝Manifest）とその処理を各Runtimeごとに実装することを想定
+ */
 import { z } from 'zod';
-import { VersionId } from 'app/src-electron/schema/version';
+import { Failable } from 'app/src-electron/schema/error';
+import {
+  ManifestContent,
+  ManifestDirectory,
+  ManifestFile,
+  ManifestLink,
+} from 'app/src-electron/schema/manifest';
+import { OsPlatform } from 'app/src-electron/schema/os';
+import { Runtime } from 'app/src-electron/schema/runtime';
+import { BytesData, Hash } from 'app/src-electron/util/binary/bytesData';
+import { Path } from 'app/src-electron/util/binary/path';
+import { CacheableAccessor } from 'app/src-electron/util/cache';
 import { errorMessage } from 'app/src-electron/util/error/construct';
 import { isError } from 'app/src-electron/util/error/error';
-import { BytesData } from '../../util/binary/bytesData';
-import { Failable } from '../../util/error/failable';
-import { versionManifestPath } from '../const';
+import { groupBy } from 'app/src-electron/util/object/groupBy';
 import { versionConfig } from '../stores/config';
+import { RuntimeMeta } from './base';
 
-export const ManifestRecord = z.object({
-  id: VersionId,
-  type: z.enum(['release', 'snapshot', 'old_beta', 'old_alpha']),
-  url: z.string(),
-  time: z.string(),
-  releaseTime: z.string(),
-  sha1: z.string(),
-  complianceLevel: z.number(),
-});
-export type ManifestRecord = z.infer<typeof ManifestRecord>;
+type JavaExecName = {
+  java: string;
+  javaw: string;
+};
 
-export const ManifestJson = z.object({
-  latest: z.object({ release: z.string(), snapshot: z.string() }),
-  versions: z.array(ManifestRecord),
-});
-export type ManifestJson = z.infer<typeof ManifestJson>;
+export abstract class RuntimeManifest<AllManifest, R extends Runtime> {
+  /** RuntimeのManifestファイルを操作 */
+  private accessor: CacheableAccessor<AllManifest>;
+  /** 設定するRuntimeの名前 */
+  static readonly manifestName: Runtime['type'];
 
-const MANIFEST_URL =
-  'https://launchermeta.mojang.com/mc/game/version_manifest_v2.json';
+  protected constructor(accessor: CacheableAccessor<AllManifest>) {
+    this.accessor = accessor;
+  }
 
-/** version_manifest_v2.jsonを取得して内容を返す */
-export async function getVersionMainfest(): Promise<Failable<ManifestJson>> {
-  // URLからデータを取得 (内容が変わっている可能性があるのでsha1チェックは行わない)
-  const response = await BytesData.fromURL(MANIFEST_URL);
+  /**
+   * Manifestのハンドラーを生成
+   *
+   * 以下のプログラムを継承先で実装すること
+   * ```ts
+   * static setRuntimeManifest(
+   *   validator: z.ZodDefault<z.ZodSchema<AllManifest, z.ZodTypeDef, any>>,
+   *   manifestPath: Path,
+   *   manifestUrl: string
+   * ) {
+   *   return new RuntimeManifest(
+   *     this.getCacheableAccessor(validator, manifestPath, manifestUrl)
+   *   );
+   * }
+   * ```
+   *
+   * このメソッドを呼び出すことで、RuntimeManifestのインスタンスを生成する
+   */
+  static setRuntimeManifest(
+    validator: z.ZodDefault<z.ZodSchema<any, z.ZodTypeDef, any>>,
+    manifestPath: Path,
+    manifestUrl: string
+  ) {
+    throw new Error('setRuntimeManifest() not implemented');
+  }
 
-  // 失敗した場合ローカルから取得
-  if (isError(response)) return getLocalVersionMainfest();
+  protected static getCacheableAccessor<_AllManifest>(
+    validator: z.ZodDefault<z.ZodSchema<_AllManifest, z.ZodTypeDef, any>>,
+    manifestPath: Path,
+    manifestUrl: string
+  ) {
+    const getter = async (): Promise<Failable<_AllManifest>> => {
+      const manifestHash = versionConfig.get('runtimes_manifest_sha1')?.[
+        this.manifestName
+      ];
+      const hash: Hash | undefined = manifestHash
+        ? {
+            type: 'sha1',
+            value: manifestHash,
+          }
+        : undefined;
+      const urlRes = await BytesData.fromPathOrUrl(
+        manifestPath,
+        manifestUrl,
+        hash
+      );
+      if (isError(urlRes)) return urlRes;
+      return urlRes.json(validator);
+    };
 
-  // 成功した場合ローカルに保存
-  versionConfig.set('version_manifest_v2_sha1', await response.hash('sha1'));
-  const failableWrite = versionManifestPath.write(response);
-  if (isError(failableWrite)) return getLocalVersionMainfest();
+    const setter = async (value: _AllManifest): Promise<Failable<void>> => {
+      const TxtValue = JSON.stringify(value);
+      const bytesValue = await BytesData.fromText(TxtValue);
+      if (isError(bytesValue)) return bytesValue;
 
-  return response.json(ManifestJson);
+      const sha1Hash = await bytesValue.hash('sha1');
+      versionConfig.set('runtimes_manifest_sha1', {
+        [this.manifestName]: sha1Hash,
+      });
+
+      return manifestPath.writeText(TxtValue);
+    };
+
+    return new CacheableAccessor(getter, setter);
+  }
+
+  /**
+   * JavaRuntimeをダウンロードしておく場所
+   */
+  protected abstract getInstallPath(
+    installBasePath: Path,
+    runtime: R,
+    osPlatform: OsPlatform
+  ): Path;
+
+  /**
+   * Runtime特有のManifestから標準的な表現である`ManifestContent`に整形する
+   */
+  protected abstract getManifestContent(
+    manifest: AllManifest,
+    runtime: R,
+    osPlatForm: OsPlatform
+  ): Promise<Failable<ManifestContent>>;
+
+  /**
+   * Java実行ファイル名をOS別に指定する
+   */
+  protected abstract getRuntimeFileNames(osPlatForm: OsPlatform): JavaExecName;
+
+  /**
+   * 各Runtimeに対応したManifestから生成した必要なファイル一覧を`manifest`引数に渡すことで，
+   * 必要なファイルの展開が実行される
+   */
+  protected async extractFilesFromManifest(
+    installPath: Path,
+    manifest: ManifestContent
+  ): Promise<Failable<void>> {
+    return _extractFilesFromManifest(installPath, manifest);
+  }
+
+  /**
+   * Manifestによって展開されたファイル群の中からJava実行ファイルのパスを取得する
+   *
+   * 第１戻値に`java`, 第２戻値に`javaw`が入る
+   */
+  protected manifest2JavaPath(
+    manifestContent: ManifestContent,
+    javaExecName: JavaExecName
+  ): Failable<[[string, ManifestFile], [string, ManifestFile]]> {
+    const java = Object.entries(manifestContent.files).find(
+      ([k, value]) => k.endsWith(javaExecName.java) && value.type === 'file'
+    ) as [string, ManifestFile];
+    if (java === undefined)
+      return errorMessage.data.path.notFound({
+        type: 'file',
+        path: 'MISSING JAVA RUNTIME FILE PATH',
+      });
+
+    const javaw = Object.entries(manifestContent.files).find(
+      ([k, value]) => k.endsWith(javaExecName.javaw) && value.type === 'file'
+    ) as [string, ManifestFile];
+    if (javaw === undefined)
+      return errorMessage.data.path.notFound({
+        type: 'file',
+        path: 'MISSING JAVAW RUNTIME FILE PATH',
+      });
+
+    return [java, javaw];
+  }
+
+  /**
+   * `installBasePath`に指定した場所を基準にRuntimeをインストールする
+   */
+  async install(
+    installBasePath: Path,
+    runtime: R,
+    osPlatform: OsPlatform
+  ): Promise<Failable<RuntimeMeta>> {
+    // RuntimeのManifestを取得
+    const allManifest = await this.accessor.get();
+    if (isError(allManifest)) return allManifest;
+
+    // 取得したManifestから対象のOSのManifestを取得
+    const osManifest = await this.getManifestContent(
+      allManifest,
+      runtime,
+      osPlatform
+    );
+    if (isError(osManifest)) return osManifest;
+
+    // 取得したManifestから必要なファイル類を生成する
+    const installPath = this.getInstallPath(
+      installBasePath,
+      runtime,
+      osPlatform
+    );
+    const extractRes = await this.extractFilesFromManifest(
+      installPath,
+      osManifest
+    );
+    if (isError(extractRes)) return extractRes;
+
+    // 生成したファイル群の中から実行パスを特定する
+    const runtimeFileNames = this.getRuntimeFileNames(osPlatform);
+    const javaPaths = this.manifest2JavaPath(osManifest, runtimeFileNames);
+    if (isError(javaPaths)) return javaPaths;
+
+    return {
+      base: { path: installPath.path },
+      java: {
+        path: installPath.child(javaPaths[0][0]).path,
+        sha1: javaPaths[0][1].downloads.raw.sha1,
+      },
+      javaw: {
+        path: installPath.child(javaPaths[1][0]).path,
+        sha1: javaPaths[1][1].downloads.raw.sha1,
+      },
+    };
+  }
 }
 
-/** ローカルから取得 */
-async function getLocalVersionMainfest(): Promise<Failable<ManifestJson>> {
-  if (!versionManifestPath.exists())
-    return errorMessage.data.path.notFound({
-      type: 'file',
-      path: versionManifestPath.path,
+// テスト用に実装を分離
+async function _extractFilesFromManifest(
+  installPath: Path,
+  manifest: ManifestContent
+): Promise<Failable<void>> {
+  await installPath.emptyDir();
+
+  const { directory, link, file } = groupBy(
+    Object.entries(manifest.files).map(([k, v]) => ({
+      path: installPath.child(k),
+      entry: v,
+    })),
+    (x) => x.entry.type
+  ) as {
+    directory: { path: Path; entry: ManifestDirectory }[] | undefined;
+    link: { path: Path; entry: ManifestLink }[] | undefined;
+    file: { path: Path; entry: ManifestFile }[] | undefined;
+  };
+
+  if (directory) await Promise.all(directory.map(({ path }) => path.mkdir()));
+
+  if (file) {
+    const results = await Promise.all(
+      file.map(async ({ path, entry }) => {
+        const urlRes = await BytesData.fromURL(entry.downloads.raw.url);
+        if (isError(urlRes)) return urlRes;
+        const writeRes = await path.write(urlRes);
+        if (isError(writeRes)) return writeRes;
+      })
+    );
+    const err = results.find(isError);
+    if (err) return err;
+  }
+
+  if (link) {
+    const results = await Promise.all(
+      link.map(async ({ path, entry }) => path.mklink(path.child(entry.target)))
+    );
+    const err = results.find(isError);
+    if (err) return err;
+  }
+}
+
+/** In Source Testing */
+if (import.meta.vitest) {
+  const { test, expect, vi } = import.meta.vitest;
+  const { Path } = await import('src-electron/util/binary/path');
+
+  // 一時使用フォルダを初期化
+  const workPath = new Path(__dirname).child('work');
+  workPath.mkdir();
+
+  // 実際にはUrlにアクセスせず、url文字列を結果として返す
+  // TODO: テスト用にダミーのURLを返すようにする
+  // const urlCreateReadStreamSpy = vi.spyOn(Url.prototype, 'createReadStream');
+  // urlCreateReadStreamSpy.mockImplementation(function (this: Url) {
+  //   return Bytes.fromString(this.url.toString()).createReadStream();
+  // });
+
+  const file = (url: string) => ({
+    type: 'file' as const,
+    executable: false,
+    downloads: {
+      raw: { url, sha1: '', size: 111 },
+    },
+  });
+  const directory = { type: 'directory' as const };
+
+  const testCases: TestCase[] = [
+    {
+      explain: 'file',
+      manifest: { 'foo.txt': file('https://a.com/') },
+      files: [{ path: 'foo.txt', value: 'https://a.com/' }],
+    },
+    {
+      explain: 'subfile',
+      manifest: {
+        foo: directory,
+        'foo/bar.txt': file('https://foo/bar.com/'),
+        'bar.txt': file('https://bar.com/'),
+        buz: directory,
+      },
+      files: [
+        { path: 'foo/bar.txt', value: 'https://foo/bar.com/' },
+        { path: 'bar.txt', value: 'https://bar.com/' },
+      ],
+      dirs: [{ path: 'foo' }, { path: 'buz' }],
+    },
+    {
+      explain: 'link',
+      manifest: {
+        'a.txt': file('https://a.com/'),
+        'foo.lnk': { type: 'link', target: '../a.txt' },
+      },
+      links: [{ path: 'foo.lnk', target: 'hello' }],
+    },
+  ];
+
+  test.each(
+    testCases.map((testCase, index) => ({
+      explain: testCase.explain,
+      testCase,
+      index,
+    }))
+  )('$explain', async ({ testCase, index }) => {
+    const dirPath = workPath.child(`${index}`);
+    await dirPath.remove();
+    const res = await _extractFilesFromManifest(dirPath, {
+      files: testCase.manifest,
     });
+    expect(isError(res)).toBe(false);
 
-  const manifestData = await versionManifestPath.read();
+    for (const file of testCase.files ?? []) {
+      expect(await dirPath.child(file.path).readText()).toBe(file.value);
+    }
+    for (const link of testCase.links ?? []) {
+      const stat = await dirPath.child(link.path).stat();
+      if (isError(stat)) continue;
+      expect(stat.nlink).greaterThan(1); // symlinkではなく、ハードリンクなのでリンクの数が1以上かどうかで判断
+    }
+    for (const dir of testCase.dirs ?? []) {
+      expect(await dirPath.child(dir.path).isDirectory()).toBe(true);
+    }
+  });
 
-  if (isError(manifestData)) return manifestData;
-
-  const manifestSha1 = versionConfig.get('version_manifest_v2_sha1');
-  if ((await manifestData.hash('sha1')) !== manifestSha1)
-    return errorMessage.data.hashNotMatch({
-      hashtype: 'sha1',
-      type: 'file',
-      path: versionManifestPath.path,
-    });
-
-  return manifestData.json(ManifestJson);
+  type TestCase = {
+    explain: string;
+    manifest: ManifestContent['files'];
+    files?: { path: string; value: string }[];
+    links?: { path: string; target: string }[];
+    dirs?: { path: string }[];
+  };
 }

--- a/src-electron/source/runtime/manifest.ts
+++ b/src-electron/source/runtime/manifest.ts
@@ -88,7 +88,7 @@ export abstract class JavaRuntimeInstaller<
       return urlRes.json(validator);
     };
 
-    const setter = async (value: RuntimeManifest): Promise<Failable<void>> => {
+    const setter = async (value: RM): Promise<Failable<void>> => {
       const TxtValue = JSON.stringify(value);
       const bytesValue = await BytesData.fromText(TxtValue);
       if (isError(bytesValue)) return bytesValue;
@@ -107,7 +107,7 @@ export abstract class JavaRuntimeInstaller<
   /**
    * Runtimeのバージョン（`java-runtime-alpha`など）を指定する
    */
-  protected abstract getRuntimeVersion(runtime: R): string;
+  abstract getRuntimeVersion(runtime: R): string;
 
   /**
    * Runtime特有のManifestから標準的な表現である`ManifestContent`に整形する

--- a/src-electron/source/runtime/manifest.ts
+++ b/src-electron/source/runtime/manifest.ts
@@ -323,15 +323,14 @@ if (import.meta.vitest) {
   const { Path } = await import('src-electron/util/binary/path');
 
   // 一時使用フォルダを初期化
-  const workPath = new Path(__dirname).child('work');
-  workPath.mkdir();
+  const workPath = new Path(__dirname).child('work', 'manifest');
+  await workPath.emptyDir();
 
   // 実際にはUrlにアクセスせず、url文字列を結果として返す
-  // TODO: テスト用にダミーのURLを返すようにする
-  // const urlCreateReadStreamSpy = vi.spyOn(Url.prototype, 'createReadStream');
-  // urlCreateReadStreamSpy.mockImplementation(function (this: Url) {
-  //   return Bytes.fromString(this.url.toString()).createReadStream();
-  // });
+  const urlCreateReadStreamSpy = vi.spyOn(BytesData, 'fromURL');
+  urlCreateReadStreamSpy.mockImplementation(function (url: string) {
+    return BytesData.fromText(url);
+  });
 
   const file = (url: string) => ({
     type: 'file' as const,

--- a/src-electron/source/runtime/manifest.ts
+++ b/src-electron/source/runtime/manifest.ts
@@ -56,7 +56,6 @@ export abstract class RuntimeManifest<AllManifest, R extends Runtime> {
    * このメソッドを呼び出すことで、RuntimeManifestのインスタンスを生成する
    */
   static setRuntimeManifest(
-    validator: z.ZodDefault<z.ZodSchema<any, z.ZodTypeDef, any>>,
     manifestPath: Path,
     manifestUrl: string
   ) {
@@ -64,7 +63,7 @@ export abstract class RuntimeManifest<AllManifest, R extends Runtime> {
   }
 
   protected static getCacheableAccessor<_AllManifest>(
-    validator: z.ZodDefault<z.ZodSchema<_AllManifest, z.ZodTypeDef, any>>,
+    validator: z.ZodSchema<_AllManifest, z.ZodTypeDef, any>,
     manifestPath: Path,
     manifestUrl: string
   ) {

--- a/src-electron/source/runtime/minecraft.ts
+++ b/src-electron/source/runtime/minecraft.ts
@@ -1,26 +1,25 @@
-import { z } from 'zod';
 import { Failable } from 'app/src-electron/schema/error';
 import { ManifestContent } from 'app/src-electron/schema/manifest';
 import { BytesData } from 'app/src-electron/util/binary/bytesData';
 import { errorMessage } from 'app/src-electron/util/error/construct';
 import { isError } from 'app/src-electron/util/error/error';
 import { OsPlatform } from '../../schema/os';
-import { MinecraftRuntime } from '../../schema/runtime';
+import { McRuntimeManifest, MinecraftRuntime } from '../../schema/runtime';
 import { Path } from '../../util/binary/path';
-import { RuntimeManifest } from './manifest';
+import { JavaRuntimeInstaller } from './manifest';
 
 export const minecraftRuntimeManifestUrl =
   'https://launchermeta.mojang.com/v1/products/java-runtime/2ec0cc96c44e5a76b9c8b7c39df7210883d12871/all.json';
 
-export class MinecraftRuntimeInstaller extends RuntimeManifest<
-  AllManifest,
+export class MinecraftRuntimeInstaller extends JavaRuntimeInstaller<
+  McRuntimeManifest,
   MinecraftRuntime
 > {
   static readonly manifestName = 'minecraft' as const;
 
   static setRuntimeManifest(manifestPath: Path, manifestUrl: string) {
     return new MinecraftRuntimeInstaller(
-      this.getCacheableAccessor(AllManifest, manifestPath, manifestUrl)
+      this.getCacheableAccessor(McRuntimeManifest, manifestPath, manifestUrl)
     );
   }
 
@@ -29,7 +28,7 @@ export class MinecraftRuntimeInstaller extends RuntimeManifest<
   }
 
   protected async getManifestContent(
-    manifest: AllManifest,
+    manifest: McRuntimeManifest,
     runtime: MinecraftRuntime,
     osPlatForm: OsPlatform
   ): Promise<Failable<ManifestContent>> {
@@ -73,25 +72,6 @@ export class MinecraftRuntimeInstaller extends RuntimeManifest<
     }
   }
 }
-
-const Manifest = z.object({
-  manifest: z.object({
-    sha1: z.string(),
-    size: z.number(),
-    url: z.string(),
-  }),
-});
-
-const OsManifest = z.record(z.string(), z.array(Manifest).optional());
-
-const AllManifest = z.object({
-  linux: OsManifest,
-  'mac-os': OsManifest,
-  'mac-os-arm64': OsManifest,
-  'windows-x64': OsManifest,
-  'windows-arm64': OsManifest,
-});
-type AllManifest = z.infer<typeof AllManifest>;
 
 /** In Source Testing */
 if (import.meta.vitest) {

--- a/src-electron/source/runtime/minecraft.ts
+++ b/src-electron/source/runtime/minecraft.ts
@@ -6,19 +6,18 @@ import { MinecraftRuntime } from '../../schema/runtime';
 import { Path } from '../../util/binary/path';
 import { RuntimeManifest } from './manifest';
 
+export const minecraftRuntimeManifestUrl =
+  'https://launchermeta.mojang.com/v1/products/java-runtime/2ec0cc96c44e5a76b9c8b7c39df7210883d12871/all.json';
+
 export class MinecraftRuntimeInstaller extends RuntimeManifest<
   AllManifest,
   MinecraftRuntime
 > {
   static readonly manifestName = 'minecraft' as const;
 
-  static setRuntimeManifest(
-    validator: z.ZodDefault<z.ZodSchema<AllManifest, z.ZodTypeDef, any>>,
-    manifestPath: Path,
-    manifestUrl: string
-  ) {
+  static setRuntimeManifest(manifestPath: Path, manifestUrl: string) {
     return new MinecraftRuntimeInstaller(
-      this.getCacheableAccessor(validator, manifestPath, manifestUrl)
+      this.getCacheableAccessor(AllManifest, manifestPath, manifestUrl)
     );
   }
 
@@ -43,10 +42,6 @@ export class MinecraftRuntimeInstaller extends RuntimeManifest<
     throw new Error('Method not implemented.');
   }
 }
-
-// const allManifestUrl = new Url(
-//   'https://launchermeta.mojang.com/v1/products/java-runtime/2ec0cc96c44e5a76b9c8b7c39df7210883d12871/all.json'
-// );
 
 // export class MinecraftRuntimeInstaller
 //   implements RuntimeInstaller<MinecraftRuntime>

--- a/src-electron/source/runtime/minecraft.ts
+++ b/src-electron/source/runtime/minecraft.ts
@@ -122,7 +122,6 @@ if (import.meta.vitest) {
         },
         'windows-x64'
       );
-      console.log(installResult);
       expect(!isError(installResult)).toBe(true);
     },
     1000 * 1000

--- a/src-electron/source/runtime/minecraft.ts
+++ b/src-electron/source/runtime/minecraft.ts
@@ -106,7 +106,7 @@ if (import.meta.vitest) {
   );
   await workPath.emptyDir();
 
-  test(
+  test.skip(
     'minecraft',
     async () => {
       const minecraft = MinecraftRuntimeInstaller.setRuntimeManifest(

--- a/src-electron/source/runtime/minecraft.ts
+++ b/src-electron/source/runtime/minecraft.ts
@@ -23,7 +23,7 @@ export class MinecraftRuntimeInstaller extends JavaRuntimeInstaller<
     );
   }
 
-  protected getRuntimeVersion(runtime: MinecraftRuntime): string {
+  getRuntimeVersion(runtime: MinecraftRuntime): string {
     return runtime.version;
   }
 

--- a/src-electron/source/runtime/minecraft.ts
+++ b/src-electron/source/runtime/minecraft.ts
@@ -75,35 +75,38 @@ export class MinecraftRuntimeInstaller extends JavaRuntimeInstaller<
 
 /** In Source Testing */
 if (import.meta.vitest) {
-  const { test, expect } = import.meta.vitest;
-  const { Path } = await import('src-electron/util/binary/path');
-  const path = await import('path');
+  const { describe, test, expect } = import.meta.vitest;
 
-  // 一時使用フォルダを初期化
-  const workPath = new Path(__dirname).child(
-    'work',
-    path.basename(__filename, '.ts')
-  );
-  await workPath.emptyDir();
+  describe('minecraft runtime', async () => {
+    const { Path } = await import('src-electron/util/binary/path');
+    const path = await import('path');
 
-  test.skip(
-    'minecraft',
-    async () => {
-      const minecraft = MinecraftRuntimeInstaller.setRuntimeManifest(
-        workPath.child('all.json'),
-        minecraftRuntimeManifestUrl
-      );
+    // 一時使用フォルダを初期化
+    const workPath = new Path(__dirname).child(
+      'work',
+      path.basename(__filename, '.ts')
+    );
+    await workPath.emptyDir();
 
-      const installResult = await minecraft.install(
-        workPath,
-        {
-          type: 'minecraft',
-          version: 'java-runtime-gamma',
-        },
-        'windows-x64'
-      );
-      expect(!isError(installResult)).toBe(true);
-    },
-    1000 * 1000
-  );
+    test.skip(
+      'minecraft',
+      async () => {
+        const minecraft = MinecraftRuntimeInstaller.setRuntimeManifest(
+          workPath.child('all.json'),
+          minecraftRuntimeManifestUrl
+        );
+
+        const installResult = await minecraft.install(
+          workPath,
+          {
+            type: 'minecraft',
+            version: 'java-runtime-gamma',
+          },
+          'windows-x64'
+        );
+        expect(!isError(installResult)).toBe(true);
+      },
+      1000 * 1000
+    );
+  });
 }

--- a/src-electron/source/runtime/minecraft.ts
+++ b/src-electron/source/runtime/minecraft.ts
@@ -1,0 +1,200 @@
+import { z } from 'zod';
+import { Failable } from 'app/src-electron/schema/error';
+import { ManifestContent } from 'app/src-electron/schema/manifest';
+import { OsPlatform } from '../../schema/os';
+import { MinecraftRuntime } from '../../schema/runtime';
+import { Path } from '../../util/binary/path';
+import { RuntimeManifest } from './manifest';
+
+export class MinecraftRuntimeInstaller extends RuntimeManifest<
+  AllManifest,
+  MinecraftRuntime
+> {
+  static readonly manifestName = 'minecraft' as const;
+
+  static setRuntimeManifest(
+    validator: z.ZodDefault<z.ZodSchema<AllManifest, z.ZodTypeDef, any>>,
+    manifestPath: Path,
+    manifestUrl: string
+  ) {
+    return new MinecraftRuntimeInstaller(
+      this.getCacheableAccessor(validator, manifestPath, manifestUrl)
+    );
+  }
+
+  protected getInstallPath(
+    installBasePath: Path,
+    runtime: MinecraftRuntime,
+    osPlatform: OsPlatform
+  ): Path {
+    throw new Error('Method not implemented.');
+  }
+  protected getManifestContent(
+    manifest: AllManifest,
+    runtime: MinecraftRuntime,
+    osPlatForm: OsPlatform
+  ): Promise<Failable<ManifestContent>> {
+    throw new Error('Method not implemented.');
+  }
+  protected getRuntimeFileNames(osPlatForm: OsPlatform): {
+    java: string;
+    javaw: string;
+  } {
+    throw new Error('Method not implemented.');
+  }
+}
+
+// const allManifestUrl = new Url(
+//   'https://launchermeta.mojang.com/v1/products/java-runtime/2ec0cc96c44e5a76b9c8b7c39df7210883d12871/all.json'
+// );
+
+// export class MinecraftRuntimeInstaller
+//   implements RuntimeInstaller<MinecraftRuntime>
+// {
+//   private manifestPath: Path;
+
+//   constructor(manifestPath: Path) {
+//     this.manifestPath = manifestPath;
+//   }
+
+//   async install(
+//     installPath: Path,
+//     runtime: MinecraftRuntime,
+//     osPlatform: OsPlatform
+//   ): Promise<Failable<RuntimeMeta>> {
+//     const manifestJson = new Json(AllManifest);
+
+//     // allManifestJsonの内容をファイルにキャッシュしつつ取得
+//     let allManifest = await this.manifestPath.into(manifestJson);
+//     if (allManifest.isErr) {
+//       await allManifestUrl.into(this.manifestPath);
+//       allManifest = await this.manifestPath.into(manifestJson);
+//       if (allManifest.isErr) return allManifest;
+//     }
+
+//     // 取得したRuntimeManifestから対象のOSのManifestを取得
+//     const osNameMap = {
+//       debian: 'linux',
+//       redhat: 'linux',
+//       'mac-os': 'mac-os',
+//       'mac-os-arm64': 'mac-os-arm64',
+//       'windows-x64': 'windows-x64',
+//     } as const;
+//     const osManifest =
+//       allManifest.value()[osNameMap[osPlatform]][runtime.version];
+//     if (osManifest === undefined) return err.error('missing manifest');
+//     if (osManifest.length === 0) return err.error('missing manifest');
+//     const targetManifestBytes = await BytesData.fromURL(
+//       osManifest[0].manifest.url
+//     );
+//     if (isError(targetManifestBytes)) return targetManifestBytes;
+//     const manifestFiles = await targetManifestBytes.json();
+//     // const result = await new Url().into(
+//     //   new Json(ManifestContent)
+//     // );
+//     // if (result.isErr) return result;
+//     // const manifestFiles = result.value();
+//     // 取得したManifestから必要なファイル類を生成する
+//     await extractFilesFromManifest(installPath, manifestFiles);
+
+//     const runtimeFileNames = getRuntimeFileNames(osPlatform);
+
+//     const java = Object.entries(manifestFiles.files).find(
+//       ([k, value]) => k.endsWith(runtimeFileNames.java) && value.type === 'file'
+//     ) as [string, ManifestFile];
+//     if (java === undefined) return err.error('MISSING JAVA RUNTIME FILE PATH');
+
+//     const javaw = Object.entries(manifestFiles.files).find(
+//       ([k, value]) =>
+//         k.endsWith(runtimeFileNames.javaw) && value.type === 'file'
+//     ) as [string, ManifestFile];
+//     if (javaw === undefined)
+//       return err.error('MISSING JAVAW RUNTIME FILE PATH');
+
+//     return ok({
+//       base: { path: installPath.path },
+//       javaw: {
+//         path: installPath.child(java[0]).path,
+//         sha1: java[1].downloads.raw.sha1,
+//       },
+//       java: {
+//         path: installPath.child(javaw[0]).path,
+//         sha1: javaw[1].downloads.raw.sha1,
+//       },
+//     });
+//   }
+
+//   getInstallPath(
+//     installBasePath: Path,
+//     runtime: MinecraftRuntime,
+//     osPlatform: OsPlatform
+//   ): Path {
+//     return installBasePath.child('minecraft', runtime.version, osPlatform);
+//   }
+// }
+
+// function getRuntimeFileNames(osPlatform: OsPlatform) {
+//   switch (osPlatform) {
+//     case 'windows-x64':
+//       return { java: 'java.exe', javaw: 'javaw.exe' };
+//     case 'mac-os':
+//     case 'mac-os-arm64':
+//       return { java: 'java', javaw: 'java' };
+//     case 'debian':
+//     case 'redhat':
+//       return { java: 'java', javaw: 'java' };
+//   }
+// }
+
+const Manifest = z.object({
+  manifest: z.object({
+    sha1: z.string(),
+    size: z.number(),
+    url: z.string(),
+  }),
+});
+
+const OsManifest = z.record(z.string(), z.array(Manifest).optional());
+
+const AllManifest = z.object({
+  linux: OsManifest,
+  'mac-os': OsManifest,
+  'mac-os-arm64': OsManifest,
+  'windows-x64': OsManifest,
+  'windows-arm64': OsManifest,
+});
+type AllManifest = z.infer<typeof AllManifest>;
+
+/** In Source Testing */
+if (import.meta.vitest) {
+  const { test, expect } = import.meta.vitest;
+  const { Path } = await import('src-electron/util/binary/path');
+  const path = await import('path');
+
+  // 一時使用フォルダを初期化
+  const workPath = new Path(__dirname).child(
+    'work',
+    path.basename(__filename, '.ts')
+  );
+  workPath.mkdir();
+
+  test.skip(
+    'minecraft',
+    async () => {
+      const minecraft = new MinecraftRuntimeInstaller(
+        workPath.child('01', 'cache')
+      );
+
+      const installResult = await minecraft.install(
+        workPath.child('01', 'java-runtime-alpha'),
+        {
+          type: 'minecraft',
+          version: 'java-runtime-alpha',
+        },
+        'windows-x64'
+      );
+      expect(installResult.isOk).toBe(true);
+    },
+    1000 * 1000
+  );
+}

--- a/src-electron/source/runtime/runtime.ts
+++ b/src-electron/source/runtime/runtime.ts
@@ -200,7 +200,10 @@ export class RuntimeContainer {
       segments.push('universal', `${runtime.majorVersion}.json`);
     } else {
       const installer = this.installerMap[runtime.type];
-      segments.push(runtime.type, `${installer.getRuntimeVersion(runtime)}.json`);
+      segments.push(
+        runtime.type,
+        `${installer.getRuntimeVersion(runtime)}.json`
+      );
     }
 
     return this.metaDirPath.child(...segments);

--- a/src-electron/source/runtime/runtime.ts
+++ b/src-electron/source/runtime/runtime.ts
@@ -280,7 +280,7 @@ if (import.meta.vitest) {
   ];
 
   // テスト実行に時間がかかることに加え，APIサーバーからのキックが頻発するため，テストはSkip
-  test.skip.each(
+  test.each(
     osPlatforms.flatMap((os) => runtimes.map((runtime) => ({ runtime, os })))
   )(
     '$os $runtime.explain',

--- a/src-electron/source/runtime/runtime.ts
+++ b/src-electron/source/runtime/runtime.ts
@@ -217,6 +217,7 @@ export class RuntimeContainer {
 /** In Source Testing */
 if (import.meta.vitest) {
   const { test, expect } = import.meta.vitest;
+  const { sleep } = await import('app/src-electron/util/promise/sleep');
   const path = await import('path');
 
   // 一時使用フォルダを初期化
@@ -278,7 +279,8 @@ if (import.meta.vitest) {
     { os: 'mac-os-arm64', explain: 'universal-8' },
   ];
 
-  test.each(
+  // テスト実行に時間がかかることに加え，APIサーバーからのキックが頻発するため，テストはSkip
+  test.skip.each(
     osPlatforms.flatMap((os) => runtimes.map((runtime) => ({ runtime, os })))
   )(
     '$os $runtime.explain',
@@ -295,8 +297,6 @@ if (import.meta.vitest) {
         missingCases.find(
           (x) => x.os === testCase.os && x.explain === testCase.runtime.explain
         ) === undefined;
-
-      console.log(readyResult);
       expect(isValid(readyResult)).toBe(isValidPair);
 
       // アンインストール

--- a/src-electron/source/runtime/runtime.ts
+++ b/src-electron/source/runtime/runtime.ts
@@ -1,24 +1,22 @@
-import { z } from 'zod';
 import { GroupProgressor } from 'app/src-electron/common/progress';
 import { OsPlatform } from 'app/src-electron/schema/os';
 import {
-  JavaComponent,
   JavaMajorVersion,
   Runtime,
   UniversalRuntime,
 } from 'app/src-electron/schema/runtime';
+import { errorMessage } from 'app/src-electron/util/error/construct';
 import { BytesData } from '../../util/binary/bytesData';
 import { Path } from '../../util/binary/path';
-import { fromRuntimeError, isError } from '../../util/error/error';
+import { isError, isValid } from '../../util/error/error';
 import { Failable } from '../../util/error/failable';
-import { osPlatform } from '../../util/os/os';
-import { runtimePath } from '../const';
-import { versionConfig } from '../stores/config';
-import { RuntimeInstaller } from './base';
+import { RuntimeInstaller, RuntimeMeta } from './base';
 import {
   MinecraftRuntimeInstaller,
   minecraftRuntimeManifestUrl,
 } from './minecraft';
+
+let metaJson: RuntimeMeta;
 
 export class RuntimeContainer {
   private metaDirPath: Path;
@@ -47,247 +45,255 @@ export class RuntimeContainer {
     };
   }
 
-  // TODO: 続きのV2/Runtimeを実装
-}
-
-/**
- * 適切なjavaw.exeの実行パスを返す
- * 必要に応じてバイナリをダウンロードする
- */
-export async function readyJava(
-  component: JavaComponent,
-  javaw: boolean,
-  progress?: GroupProgressor
-): Promise<Failable<Path>> {
-  progress?.title({
-    key: 'server.readyJava.title',
-  });
-
-  const json = await getAllJson();
-
-  const allJsonKeyOsPlatformMap: Record<OsPlatform, keyof AllJson> = {
-    debian: 'linux',
-    redhat: 'linux',
-    'mac-os': 'mac-os',
-    'mac-os-arm64': 'mac-os-arm64',
-    'windows-x64': 'windows-x64',
-  };
-
-  if (isError(json)) return json;
-
-  const manifest =
-    json[allJsonKeyOsPlatformMap[osPlatform]][component][0].manifest;
-
-  const path = runtimePath.child(`${component}/${osPlatform}`);
-
-  const data = await getManifestJson(manifest, path.child('manifest.json'));
-
-  await installManifest(data, path, progress);
-
-  switch (osPlatform) {
-    case 'windows-x64':
-      return javaw ? path.child('bin/javaw.exe') : path.child('bin/java.exe');
-    case 'debian':
-    case 'redhat':
-      return path.child('bin/java');
-    case 'mac-os':
-    case 'mac-os-arm64':
-      return path.child('jre.bundle/Contents/Home/bin/java');
-    default:
-      throw new Error(`Unknown OS:${osPlatform}`);
+  /**
+   * 指定されたランタイムを導入して実行パスを返す
+   *
+   * キャッシュに存在する場合はそれを使用
+   *
+   * @param useJavaw windowsのみ効果あり javaw.exeのパスを返す
+   */
+  async ready(
+    runtime: Runtime,
+    osPlatform: OsPlatform,
+    useJavaw: boolean,
+    progress?: GroupProgressor
+  ): Promise<Failable<Path>> {
+    progress?.title({ key: 'server.readyJava.title' });
+    return this._ready(runtime, osPlatform, useJavaw, progress);
   }
-}
 
-// const RuntimeManifest = z.object({
-//   sha1: z.string(),
-//   size: z.number(),
-//   url: z.string(),
-// });
-// type RuntimeManifest = z.infer<typeof RuntimeManifest>;
+  private async _ready(
+    runtime: Runtime,
+    osPlatform: OsPlatform,
+    useJavaw: boolean,
+    progress?: GroupProgressor
+  ): Promise<Failable<Path>> {
+    const metaPath = this.metaPath(runtime, osPlatform);
 
-// const Runtime = z.object({
-//   availability: z.object({ group: z.number(), progress: z.literal(100) }),
-//   manifest: RuntimeManifest,
-//   version: z.object({ name: z.string(), released: z.string() }),
-// });
-// type Runtime = z.infer<typeof Runtime>;
+    // すでにインストール済み
+    const current = await this.checkExists(metaPath, useJavaw);
+    if (isValid(current)) return current;
 
-// const Runtimes = z.object({
-//   'java-runtime-alpha': Runtime.array(),
-//   'java-runtime-beta': Runtime.array(),
-//   'java-runtime-gamma': Runtime.array(),
-//   'java-runtime-delta': Runtime.array(),
-//   'jre-legacy': Runtime.array(),
-//   'minecraft-java-exe': Runtime.array(),
-// });
-// type Runtimes = z.infer<typeof Runtimes>;
+    // universalの場合はそれに対応するほかのランタイムをインストール
+    if (runtime['type'] === 'universal')
+      return this.readyUniversal(runtime, osPlatform, useJavaw);
 
-// const AllJson = z.object({
-//   gamecore: Runtimes,
-//   linux: Runtimes,
-//   'linux-i386': Runtimes,
-//   'mac-os': Runtimes,
-//   'mac-os-arm64': Runtimes,
-//   'windows-x64': Runtimes,
-//   'windows-x86': Runtimes,
-// });
-// type AllJson = z.infer<typeof AllJson>;
+    const installer = this.installerMap[runtime['type']];
+    const meta = await installer.install(
+      this.binDirPath,
+      runtime,
+      osPlatform,
+      progress
+    );
+    if (isError(meta)) return meta;
 
-async function getAllJson(): Promise<Failable<AllJson>> {
-  try {
-    const allJsonSha1 = versionConfig.get('sha1')?.runtime;
-    const data = await BytesData.fromUrlOrPath(
-      runtimePath.child('all.json'),
-      'https://launchermeta.mojang.com/v1/products/java-runtime/2ec0cc96c44e5a76b9c8b7c39df7210883d12871/all.json',
-      allJsonSha1 !== undefined
-        ? { type: 'sha1', value: allJsonSha1 }
-        : allJsonSha1,
-      true
+    const writeRes = await metaPath.writeJson(meta);
+    if (isError(writeRes)) return writeRes;
+
+    return new Path(meta[useJavaw ? 'javaw' : 'java']['path']);
+  }
+
+  /** universalだけ特殊 */
+  private async readyUniversal(
+    runtime: UniversalRuntime,
+    osPlatform: OsPlatform,
+    useJavaw: boolean
+  ) {
+    const refRuntimeOrError = await this.getUniversalConfig(
+      osPlatform,
+      runtime.majorVersion
+    );
+    if (isError(refRuntimeOrError)) return refRuntimeOrError;
+    const refRuntime = refRuntimeOrError;
+
+    const refInstallResult = await this._ready(
+      refRuntime,
+      osPlatform,
+      useJavaw
+    );
+    if (isError(refInstallResult)) return refInstallResult;
+
+    // 参照しているメタファイルの内容をコピー
+    await this.metaPath(refRuntime, osPlatform).copyTo(
+      this.metaPath(runtime, osPlatform)
     );
 
-    if (isError(data)) return data;
-
-    const json = await data.json(AllJson);
-    if (isError(json)) return json;
-    return json;
-  } catch (e) {
-    return fromRuntimeError(e);
+    return refInstallResult;
   }
-}
 
-async function getManifestJson(
-  manifest: RuntimeManifest,
-  path: Path
-): Promise<Failable<any>> {
-  const data = await BytesData.fromUrlOrPath(
-    path,
-    manifest.url,
-    {
-      type: 'sha1',
-      value: manifest.sha1,
-    },
-    true
-  );
-  if (isError(data)) return data;
+  /**
+   * 指定されたランタイムをキャッシュから削除
+   */
+  async remove(
+    runtime: Runtime,
+    osPlatform: OsPlatform
+  ): Promise<Failable<void>> {
+    const metapath = this.metaPath(runtime, osPlatform);
+    if (!metapath.exists()) return;
 
-  const json = await data.json(Manifest);
-  if (isError(json)) return json;
+    const _metaJson = await metapath.readJson(RuntimeMeta);
+    if (isError(_metaJson)) return _metaJson;
+    else metaJson = _metaJson;
 
-  return json;
-}
+    await new Path(metaJson.base.path).remove();
+    await metapath.remove();
+  }
 
-//
-// # source util/java/manifest.ts
-//
+  private async checkExists(
+    metapath: Path,
+    useJavaw: boolean
+  ): Promise<Failable<Path>> {
+    const _metaJson = await metapath.readJson(RuntimeMeta);
+    if (isError(_metaJson)) return _metaJson;
+    else metaJson = _metaJson;
 
-const ManifestDownload = z.object({
-  sha1: z.string(),
-  size: z.number(),
-  url: z.string(),
-});
-type ManifestDownload = z.infer<typeof ManifestDownload>;
+    const info = metaJson[useJavaw ? 'javaw' : 'java'];
+    const { path, sha1 } = info;
+    const binPath = new Path(path);
+    const binData = await BytesData.fromPath(binPath);
+    if (isError(binData)) return binData;
+    const binHash = await binData.hash('sha1');
+    if (isError(binHash)) return binHash;
 
-const ManifestFile = z.object({
-  downloads: z.object({
-    lzma: ManifestDownload.optional(),
-    raw: ManifestDownload,
-  }),
-  executable: z.boolean(),
-  type: z.literal('file'),
-});
-type ManifestFile = z.infer<typeof ManifestFile>;
+    if (binHash !== sha1) {
+      return errorMessage.data.hashNotMatch({
+        hashtype: 'sha1',
+        type: 'url',
+        path,
+      });
+    }
 
-const ManifestDirectory = z.object({
-  type: z.literal('directory'),
-});
-type ManifestDirectory = z.infer<typeof ManifestDirectory>;
+    return binPath;
+  }
 
-const ManifestLink = z.object({
-  target: z.string(),
-  type: z.literal('link'),
-});
-type ManifestLink = z.infer<typeof ManifestLink>;
-
-const Manifest = z.object({
-  files: z.record(
-    z.string(),
-    z.union([ManifestFile, ManifestDirectory, ManifestLink])
-  ),
-});
-type Manifest = {
-  files: {
-    [key in string]: ManifestFile | ManifestDirectory | ManifestLink;
-  };
-};
-
-/** manifest.jsonに記載されているデータをローカルに展開する */
-async function installManifest(
-  manifest: Manifest,
-  path: Path,
-  progress?: GroupProgressor
-) {
-  // 展開先の親ディレクトリを生成
-  await path.mkdir(true);
-
-  // manifestの順番でファイル/ディレクトリ/リンクを作る
-  // ディレクトリは同期的に作成し、ファイル/リンクは非同期を並列して処理
-  const promises: Promise<Failable<undefined>>[] = [];
-  const entries = Object.entries(manifest.files);
-  let processed = 0;
-
-  const numeric = progress?.numeric('file', entries.length);
-  const file = progress?.subtitle({
-    key: 'server.readyJava.file',
-    args: {
-      path: '',
-    },
-  });
-
-  for await (const [k, v] of entries) {
-    const p = path.child(k);
-    switch (v.type) {
-      case 'file':
-        const filePromise = async () => {
-          file?.setSubtitle({
-            key: 'server.readyJava.file',
-            args: { path: k },
-          });
-          const result = await BytesData.fromPathOrUrl(
-            p,
-            v.downloads.raw.url,
-            { value: v.downloads.raw.sha1, type: 'sha1' },
-            false,
-            undefined,
-            v.executable
-          );
-          numeric?.setValue(processed++);
-          if (isError(result)) return result;
-        };
-        promises.push(filePromise());
+  private metaPath(runtime: Runtime, osPlatform: OsPlatform) {
+    const segments: string[] = [];
+    switch (osPlatform) {
+      case 'windows-x64':
+        segments.push('windows', 'x64');
         break;
-      case 'directory':
-        file?.setSubtitle({
-          key: 'server.readyJava.file',
-          args: { path: k },
-        });
-        await p.mkdir();
-        numeric?.setValue(processed++);
+      case 'mac-os':
+        segments.push('mac', 'x64');
         break;
-      case 'link':
-        const linkPromise = async () => {
-          file?.setSubtitle({
-            key: 'server.readyJava.file',
-            args: { path: k },
-          });
-          await p.mklink(p.parent().child(v.target));
-          numeric?.setValue(processed++);
-          return undefined;
-        };
-        promises.push(linkPromise());
+      case 'mac-os-arm64':
+        segments.push('mac', 'arm64');
+        break;
+      case 'debian':
+      case 'redhat':
+        segments.push('linux', 'x64');
         break;
     }
+    switch (runtime.type) {
+      case 'minecraft':
+        segments.push('minecraft', `${runtime.version}.json`);
+        break;
+      case 'universal': {
+        segments.push('universal', `${runtime.majorVersion}.json`);
+        break;
+      }
+    }
+    return this.metaDirPath.child(...segments);
   }
-  // ファイル/リンクの並列処理を待機
-  await Promise.all(promises);
-  // TODO: Failureがあった場合の処理
+}
+
+// src-electron\v2\source\runtime\test\assets\cache\meta
+// こっちにランタイムの情報とパスを格納
+//
+// src-electron\v2\source\runtime\test\assets\cache\meta
+// こっちにランタイム本体のパスを格納
+//
+
+/** In Source Testing */
+if (import.meta.vitest) {
+  const { test, expect } = import.meta.vitest;
+  const path = await import('path');
+
+  // 一時使用フォルダを初期化
+  const workPath = new Path(__dirname).child(
+    'work',
+    path.basename(__filename, '.ts')
+  );
+  await workPath.mkdir();
+
+  const _getUniversalConfig = async () => {
+    return {
+      type: 'minecraft',
+      version: 'jre-legacy',
+    } as const;
+  };
+  const runtimeContainer = new RuntimeContainer(workPath, _getUniversalConfig);
+
+  const runtimes: (Runtime & { explain: string })[] = [
+    { explain: 'jre-legacy', type: 'minecraft', version: 'jre-legacy' },
+    {
+      explain: 'java-runtime-alpha',
+      type: 'minecraft',
+      version: 'java-runtime-alpha',
+    },
+    {
+      explain: 'java-runtime-beta',
+      type: 'minecraft',
+      version: 'java-runtime-beta',
+    },
+    {
+      explain: 'java-runtime-gamma',
+      type: 'minecraft',
+      version: 'java-runtime-gamma',
+    },
+    {
+      explain: 'java-runtime-delta',
+      type: 'minecraft',
+      version: 'java-runtime-delta',
+    },
+    {
+      explain: 'universal-8',
+      type: 'universal',
+      majorVersion: JavaMajorVersion.parse(21),
+    },
+  ];
+
+  const osPlatforms: OsPlatform[] = [
+    'windows-x64',
+    'mac-os',
+    'mac-os-arm64',
+    'debian',
+  ];
+
+  // 公式がランタイムを提供していない組
+  const missingCases: { os: OsPlatform; explain: string }[] = [
+    { os: 'mac-os-arm64', explain: 'jre-legacy' },
+    { os: 'mac-os-arm64', explain: 'java-runtime-alpha' },
+    { os: 'mac-os-arm64', explain: 'java-runtime-beta' },
+    { os: 'mac-os-arm64', explain: 'universal-8' },
+  ];
+
+  test.skip.each(
+    osPlatforms.flatMap((os) => runtimes.map((runtime) => ({ runtime, os })))
+  )(
+    '$os $runtime.explain',
+    async (testCase) => {
+      // インストール
+      const readyResult = await runtimeContainer.ready(
+        testCase.runtime,
+        testCase.os,
+        true
+      );
+
+      // ランタイムが提供されている組み合わせかどうかをチェック
+      const isValidPair =
+        missingCases.find(
+          (x) => x.os === testCase.os && x.explain === testCase.runtime.explain
+        ) === undefined;
+
+      expect(isValid(readyResult)).toBe(isValidPair);
+
+      // アンインストール
+      const removeResult = await runtimeContainer.remove(
+        testCase.runtime,
+        testCase.os
+      );
+      expect(isValid(removeResult)).toBe(true);
+    },
+    1000 * 1000
+  );
 }

--- a/src-electron/source/runtime/runtime.ts
+++ b/src-electron/source/runtime/runtime.ts
@@ -195,15 +195,14 @@ export class RuntimeContainer {
         segments.push('linux', 'x64');
         break;
     }
-    switch (runtime.type) {
-      case 'minecraft':
-        segments.push('minecraft', `${runtime.version}.json`);
-        break;
-      case 'universal': {
-        segments.push('universal', `${runtime.majorVersion}.json`);
-        break;
-      }
+
+    if (runtime['type'] === 'universal') {
+      segments.push('universal', `${runtime.majorVersion}.json`);
+    } else {
+      const installer = this.installerMap[runtime.type];
+      segments.push(runtime.type, installer.getRuntimeVersion(runtime));
     }
+
     return this.metaDirPath.child(...segments);
   }
 }
@@ -297,6 +296,7 @@ if (import.meta.vitest) {
           (x) => x.os === testCase.os && x.explain === testCase.runtime.explain
         ) === undefined;
 
+      console.log(readyResult);
       expect(isValid(readyResult)).toBe(isValidPair);
 
       // アンインストール

--- a/src-electron/source/server/ready.ts
+++ b/src-electron/source/server/ready.ts
@@ -1,6 +1,6 @@
+import { runtimeContainer } from 'app/src-electron/core/setup';
 import { Version } from 'app/src-electron/schema/version';
 import { WorldID } from 'app/src-electron/schema/world';
-import { readyJava } from 'app/src-electron/source/runtime/runtime';
 import { Path } from 'app/src-electron/util/binary/path';
 import { errorMessage } from 'app/src-electron/util/error/construct';
 import { isError, isValid } from 'app/src-electron/util/error/error';
@@ -64,7 +64,13 @@ export async function readyRunServer(
 
     // 実行javaを用意
     const javaSub = progress.subGroup();
-    const javaPath = await readyJava(server.component, true, javaSub);
+    // TODO: 直ちにVersionの実装を入れ替えることを踏まえて，windowsとして暫定的に実装する
+    const javaPath = await runtimeContainer.ready(
+      { type: 'minecraft', version: server.component },
+      'windows-x64',
+      true,
+      javaSub
+    );
     javaSub.delete();
 
     // 実行javaが用意できなかった場合エラー

--- a/src-electron/source/sourceLogger.ts
+++ b/src-electron/source/sourceLogger.ts
@@ -1,0 +1,3 @@
+import { rootLogger } from '../common/logger';
+
+export const sourceLoggers = () => rootLogger.source;

--- a/src-electron/source/stores/config.ts
+++ b/src-electron/source/stores/config.ts
@@ -1,9 +1,12 @@
 import Store from 'electron-store';
 import { VersionType } from 'src-electron/schema/version';
+import { Runtime } from 'app/src-electron/schema/runtime';
 import { versionsCachePath } from '../const';
 
 export type Config = {
-  version_manifest_v2_sha1?: string;
+  runtimes_manifest_sha1?: {
+    [key in Runtime['type']]: string;
+  };
   spigot_buildtool_sha1?: string;
   sha1?: {
     runtime?: string;

--- a/src-electron/source/version/base.ts
+++ b/src-electron/source/version/base.ts
@@ -1,5 +1,6 @@
 import { AllVersion, Version } from 'src-electron/schema/version';
 import { rootLogger } from 'app/src-electron/common/logger';
+import { JavaComponent } from 'app/src-electron/schema/runtime';
 import { isError, isValid } from 'app/src-electron/util/error/error';
 import { GroupProgressor } from '../../common/progress';
 import { versionsCachePath } from '../../source/const';
@@ -7,7 +8,6 @@ import { versionConfig } from '../../source/stores/config';
 import { BytesData } from '../../util/binary/bytesData';
 import { Path } from '../../util/binary/path';
 import { Failable } from '../../util/error/failable';
-import { JavaComponent } from '../runtime/runtime';
 import { eulaUnnecessaryVersionIds } from './const';
 
 export const versionLoggers = () => rootLogger.server.version;

--- a/src-electron/source/version/forge.ts
+++ b/src-electron/source/version/forge.ts
@@ -227,7 +227,7 @@ async function installForge(installerPath: Path): Promise<Failable<undefined>> {
   const javaPath = await runtimeContainer.ready(
     { type: 'universal', majorVersion: JavaMajorVersion.parse(0) },
     'windows-x64',
-    false,
+    false
   );
   if (isError(javaPath)) return javaPath;
 

--- a/src-electron/source/version/forge.ts
+++ b/src-electron/source/version/forge.ts
@@ -5,6 +5,8 @@ import {
   VersionId,
 } from 'src-electron/schema/version';
 import { GroupProgressor } from 'app/src-electron/common/progress';
+import { runtimeContainer } from 'app/src-electron/core/setup';
+import { JavaMajorVersion } from 'app/src-electron/schema/runtime';
 import { errorMessage } from 'app/src-electron/util/error/construct';
 import { isError, isValid } from 'app/src-electron/util/error/error';
 import { versionsCachePath } from '../../source/const';
@@ -13,7 +15,6 @@ import { Path } from '../../util/binary/path';
 import { interactiveProcess } from '../../util/binary/subprocess';
 import { Failable } from '../../util/error/failable';
 import { osPlatform } from '../../util/os/os';
-import { readyJava } from '../runtime/runtime';
 import {
   genGetAllVersions,
   needEulaAgreementVanilla,
@@ -221,10 +222,13 @@ async function getProgramArgumentsFromSh(shPath: Path) {
 }
 
 async function installForge(installerPath: Path): Promise<Failable<undefined>> {
-  // TODO: forgeのインストール時に使用するjavaのバージョン17で大丈夫？
-  // jre-legacyだとエラー出たのでとりあえずこれを使っている
-
-  const javaPath = await readyJava('java-runtime-gamma', false);
+  // 最新版のForgeを用いてインストールを行う
+  // TODO: 旧バージョンに対しては当該server.jarで使用するバージョンでインストールを行う
+  const javaPath = await runtimeContainer.ready(
+    { type: 'universal', majorVersion: JavaMajorVersion.parse(0) },
+    'windows-x64',
+    false,
+  );
   if (isError(javaPath)) return javaPath;
 
   const args = [

--- a/src-electron/source/version/getVersions/manifest.ts
+++ b/src-electron/source/version/getVersions/manifest.ts
@@ -68,18 +68,21 @@ export async function getVersionMainfest(
 
 /** In Source Testing */
 if (import.meta.vitest) {
-  const { test, expect } = import.meta.vitest;
-  const path = await import('path');
+  const { test, expect, describe } = import.meta.vitest;
 
-  // 一時使用フォルダを初期化
-  const workPath = new Path(__dirname).child(
-    'work',
-    path.basename(__filename, '.ts')
-  );
-  await workPath.emptyDir();
+  describe('runtime-manifest', async () => {
+    const path = await import('path');
 
-  test('manifest-handler-check', async () => {
-    const res = await getVersionMainfest(workPath, false);
-    expect(isValid(res)).toBe(true);
+    // 一時使用フォルダを初期化
+    const workPath = new Path(__dirname).child(
+      'work',
+      path.basename(__filename, '.ts')
+    );
+    await workPath.emptyDir();
+
+    test('manifest-handler-check', async () => {
+      const res = await getVersionMainfest(workPath, false);
+      expect(isValid(res)).toBe(true);
+    });
   });
 }

--- a/src-electron/source/version/getVersions/manifest.ts
+++ b/src-electron/source/version/getVersions/manifest.ts
@@ -1,0 +1,85 @@
+import { z } from 'zod';
+import { Failable } from 'app/src-electron/schema/error';
+import { VersionId } from 'app/src-electron/schema/version';
+import { BytesData } from 'app/src-electron/util/binary/bytesData';
+import { Path } from 'app/src-electron/util/binary/path';
+import { isValid } from 'app/src-electron/util/error/error';
+import { JsonSourceHandler } from 'app/src-electron/util/wrapper/jsonFile';
+
+const MANIFEST_URL =
+  'https://launchermeta.mojang.com/mc/game/version_manifest_v2.json';
+const MANIFEST_PATH = (cachePath: Path) =>
+  cachePath.child('version_manifest_v2.json');
+
+const ManifestRecordZod = z.object({
+  id: z.string().transform((val) => val as VersionId),
+  type: z.enum(['release', 'snapshot', 'old_beta', 'old_alpha']),
+  url: z.string(),
+  time: z.string(),
+  releaseTime: z.string(),
+  sha1: z.string(),
+  complianceLevel: z.number(),
+});
+export type ManifestRecord = z.infer<typeof ManifestRecordZod>;
+
+const ManifestJsonZod = z.object({
+  latest: z.object({
+    release: z.string(),
+    snapshot: z.string(),
+  }),
+  versions: ManifestRecordZod.array(),
+});
+export type ManifestJson = z.infer<typeof ManifestJsonZod>;
+
+let manifestHandler: JsonSourceHandler<ManifestJson> | undefined = undefined;
+
+/** version_manifest_v2.jsonを取得して内容を返す */
+export async function getVersionMainfest(
+  cachePath: Path,
+  useCache: boolean
+): Promise<Failable<ManifestJson>> {
+  if (!manifestHandler) {
+    manifestHandler = JsonSourceHandler.fromPath(
+      MANIFEST_PATH(cachePath),
+      ManifestJsonZod
+    );
+  }
+
+  if (useCache) {
+    const cachedManifest = await manifestHandler.read();
+    if (isValid(cachedManifest)) return cachedManifest;
+  }
+
+  // URLからデータを取得
+  const response = await BytesData.fromURL(MANIFEST_URL);
+
+  if (isValid(response)) {
+    const resJson = await response.json(ManifestJsonZod);
+    if (isValid(resJson)) {
+      // 取得したJsonを`version_manifest_v2.json`に保存する
+      await manifestHandler.write(resJson);
+    } else {
+      return resJson;
+    }
+  }
+
+  return manifestHandler.read();
+}
+
+/** In Source Testing */
+if (import.meta.vitest) {
+  const { test, expect } = import.meta.vitest;
+  const path = await import('path');
+
+  // 一時使用フォルダを初期化
+  const workPath = new Path(__dirname).child(
+    'work',
+    path.basename(__filename, '.ts')
+  );
+  await workPath.emptyDir();
+
+  test('manifest-handler-check', async () => {
+    const res = await getVersionMainfest(workPath, false);
+    expect(isValid(res)).toBe(true);
+  });
+}

--- a/src-electron/source/version/spigot.ts
+++ b/src-electron/source/version/spigot.ts
@@ -5,6 +5,7 @@ import {
   VersionId,
 } from 'src-electron/schema/version';
 import { z } from 'zod';
+import { JavaComponent } from 'app/src-electron/schema/runtime';
 import { errorMessage } from 'app/src-electron/util/error/construct';
 import { isError } from 'app/src-electron/util/error/error';
 import { GroupProgressor } from '../../common/progress';
@@ -16,7 +17,7 @@ import { interactiveProcess } from '../../util/binary/subprocess';
 import { Failable } from '../../util/error/failable';
 import { allocateTempDir } from '../../util/tempPath';
 import { getVersionMainfest } from '../runtime/manifest';
-import { JavaComponent, readyJava } from '../runtime/runtime';
+import { JavaComponentreadyJava } from '../runtime/runtime';
 import {
   genGetAllVersions,
   needEulaAgreementVanilla,

--- a/src-electron/source/version/vanilla.ts
+++ b/src-electron/source/version/vanilla.ts
@@ -1,6 +1,7 @@
 import { AllVanillaVersion, VanillaVersion } from 'src-electron/schema/version';
 import { z } from 'zod';
 import { GroupProgressor } from 'app/src-electron/common/progress';
+import { JavaComponent } from 'app/src-electron/schema/runtime';
 import { errorMessage } from 'app/src-electron/util/error/construct';
 import { isError } from 'app/src-electron/util/error/error';
 import { versionsCachePath } from '../../source/const';
@@ -8,7 +9,6 @@ import { BytesData } from '../../util/binary/bytesData';
 import { Path } from '../../util/binary/path';
 import { Failable } from '../../util/error/failable';
 import { getVersionMainfest } from '../runtime/manifest';
-import { JavaComponent } from '../runtime/runtime';
 import {
   genGetAllVersions,
   needEulaAgreementVanilla,

--- a/src-electron/source/version/vanilla.ts
+++ b/src-electron/source/version/vanilla.ts
@@ -8,12 +8,12 @@ import { versionsCachePath } from '../../source/const';
 import { BytesData } from '../../util/binary/bytesData';
 import { Path } from '../../util/binary/path';
 import { Failable } from '../../util/error/failable';
-import { getVersionMainfest } from '../runtime/manifest';
 import {
   genGetAllVersions,
   needEulaAgreementVanilla,
   VersionLoader,
 } from './base';
+import { getVersionMainfest } from './getVersions/manifest';
 
 const vanillaVersionsPath = versionsCachePath.child('vanilla');
 
@@ -94,7 +94,7 @@ export const vanillaVersionLoader: VersionLoader<VanillaVersion> = {
 };
 
 async function getAllVanillaVersions(): Promise<Failable<AllVanillaVersion>> {
-  const manifest = await getVersionMainfest();
+  const manifest = await getVersionMainfest(versionsCachePath, false);
   if (isError(manifest)) return manifest;
 
   // 1.2.5以前はマルチサーバーが存在しない
@@ -122,7 +122,7 @@ export async function getVanillaVersionJson(
   id: string
 ): Promise<Failable<VanillaVersionJson>> {
   const jsonpath = vanillaVersionsPath.child(`vanilla-${id}.json`);
-  const manifest = await getVersionMainfest();
+  const manifest = await getVersionMainfest(versionsCachePath, false);
 
   // version manifestが取得できなかった場合
   if (isError(manifest)) return manifest;

--- a/src-electron/util/binary/bytesData.ts
+++ b/src-electron/util/binary/bytesData.ts
@@ -135,7 +135,7 @@ export class BytesData {
     encoding?: BufferEncoding
   ): Promise<Failable<void>> {
     const logger = loggers().write({ path });
-    logger.info('start');
+    logger.trace('start');
     const settings: { encoding?: BufferEncoding; mode?: number } = {};
     // 実行権限を与えて保存
     if (executable) {
@@ -146,7 +146,7 @@ export class BytesData {
     }
     try {
       await promises.writeFile(path, new Uint8Array(this.data), settings);
-      logger.info('success');
+      logger.trace('success');
     } catch (e) {
       const em = fromRuntimeError(e);
       logger.error(em);

--- a/src-electron/util/binary/bytesData.ts
+++ b/src-electron/util/binary/bytesData.ts
@@ -69,7 +69,7 @@ export class BytesData {
     } catch (e) {
       const em = fromRuntimeError(e);
       logger.error(em);
-      return fromRuntimeError(e);
+      return em;
     }
   }
 
@@ -82,6 +82,13 @@ export class BytesData {
       hash,
     });
     logger.trace('start');
+
+    // ファイルが存在しない場合はエラー
+    if (!path.exists())
+      return errorMessage.data.path.notFound({
+        type: 'file',
+        path: path.path,
+      });
 
     try {
       const buffer = await promises.readFile(path.path);

--- a/src-electron/util/error/schema/core.ts
+++ b/src-electron/util/error/schema/core.ts
@@ -88,8 +88,8 @@ export type CoreErrors = {
     installFailed: ErrorMessageContent<{
       // インストールに失敗したバージョン
       version: string;
-    }>
-  }
+    }>;
+  };
 
   // gitのPATが存在しない場合
   missingPersonalAccessToken: ErrorMessageContent<{

--- a/src-electron/util/error/schema/core.ts
+++ b/src-electron/util/error/schema/core.ts
@@ -1,4 +1,6 @@
+import { OsPlatform } from 'app/src-electron/schema/os';
 import { OpLevel } from 'app/src-electron/schema/player';
+import { Runtime } from 'app/src-electron/schema/runtime';
 import { ErrorMessageContent } from './base';
 
 // ServerStarterの内部的なその他のエラー
@@ -86,6 +88,10 @@ export type CoreErrors = {
 
   runtime: {
     installFailed: ErrorMessageContent<{
+      // Runtimeの種類
+      runtimeType: Runtime['type'];
+      // インストールしようとしたOS
+      targetOs: OsPlatform;
       // インストールに失敗したバージョン
       version: string;
     }>;

--- a/src-electron/util/error/schema/core.ts
+++ b/src-electron/util/error/schema/core.ts
@@ -84,6 +84,13 @@ export type CoreErrors = {
     }>;
   };
 
+  runtime: {
+    installFailed: ErrorMessageContent<{
+      // インストールに失敗したバージョン
+      version: string;
+    }>
+  }
+
   // gitのPATが存在しない場合
   missingPersonalAccessToken: ErrorMessageContent<{
     // https://github.com/{owner}/{repo}

--- a/src-electron/util/object/groupBy.ts
+++ b/src-electron/util/object/groupBy.ts
@@ -1,0 +1,12 @@
+export function groupBy<K extends string, V>(
+  objects: V[],
+  keySelector: (item: V) => K
+): Record<K, V[]> {
+  const result = {} as Record<K, V[]>;
+  objects.forEach((obj) => {
+    const k = keySelector(obj);
+    if (result[k]) result[k].push(obj);
+    else result[k] = [obj];
+  });
+  return result;
+}

--- a/src-electron/util/wrapper/jsonFile.ts
+++ b/src-electron/util/wrapper/jsonFile.ts
@@ -1,7 +1,7 @@
 import { z, ZodTypeDef } from 'zod';
 import { Path } from '../binary/path';
 import { CacheableAccessor } from '../cache';
-import { fromRuntimeError, isError } from '../error/error';
+import { isError } from '../error/error';
 import { Failable } from '../error/failable';
 
 /**
@@ -16,24 +16,14 @@ export class JsonSourceHandler<T> {
 
   /**
    * ローカルにあるJSONを扱う
-   *
-   * `validator`には必ずDefaultを設定した状態のZodSchemaを渡すこと
    */
   static fromPath<T>(
     path: Path,
-    validator: z.ZodDefault<z.ZodSchema<T, ZodTypeDef, any>>,
+    validator: z.ZodSchema<T, ZodTypeDef, any>,
     options?: { encoding?: BufferEncoding }
   ) {
     const getter = async (): Promise<Failable<T>> => {
-      let jsonResult: Failable<T> = await path.readJson(
-        validator,
-        options?.encoding
-      );
-      if (isError(jsonResult)) jsonResult = {} as T;
-
-      const validated = await validator.safeParseAsync(jsonResult);
-      if (validated.success) return validated.data;
-      return fromRuntimeError(validated.error);
+      return path.readJson(validator, options?.encoding);
     };
 
     const setter = async (value: T): Promise<Failable<void>> => {

--- a/src-electron/util/wrapper/jsonFile.ts
+++ b/src-electron/util/wrapper/jsonFile.ts
@@ -34,7 +34,7 @@ export class JsonSourceHandler<T> {
       const defaultVal = validator.safeParse({});
       if (!defaultVal.success) return res;
 
-      await setter(defaultVal.data)
+      await setter(defaultVal.data);
       return defaultVal.data;
     };
 

--- a/src/i18n/en-US/Other/error.ts
+++ b/src/i18n/en-US/Other/error.ts
@@ -240,7 +240,7 @@ export const enUSError: MessageSchema['error'] = {
       installFailed: {
         title: 'Failed to install a Java runtime',
         desc: 'Wait a few moments and run again. ({version})',
-      }
+      },
     },
     missingPersonalAccessToken: {
       title: 'Personal access token for {owner}/{repo} dose not exist',

--- a/src/i18n/en-US/Other/error.ts
+++ b/src/i18n/en-US/Other/error.ts
@@ -236,6 +236,12 @@ export const enUSError: MessageSchema['error'] = {
         title: 'vanilla does not exist in version {version}',
       },
     },
+    runtime: {
+      installFailed: {
+        title: 'Failed to install a Java runtime',
+        desc: 'Wait a few moments and run again. ({version})',
+      }
+    },
     missingPersonalAccessToken: {
       title: 'Personal access token for {owner}/{repo} dose not exist',
     },

--- a/src/i18n/ja/Other/error.ts
+++ b/src/i18n/ja/Other/error.ts
@@ -241,7 +241,7 @@ export const jaError: ErrorTranslationTypes & ErrorDialogTitles = {
       installFailed: {
         title: 'Javaランタイムのインストールに失敗しました',
         desc: '数分時間をあけて再度お試しください．({version})',
-      }
+      },
     },
     missingPersonalAccessToken: {
       title: '{owner}/{repo}のパーソナルアクセストークンが存在しません',

--- a/src/i18n/ja/Other/error.ts
+++ b/src/i18n/ja/Other/error.ts
@@ -237,6 +237,12 @@ export const jaError: ErrorTranslationTypes & ErrorDialogTitles = {
         title: 'バージョン{version}のvanillaは存在しません',
       },
     },
+    runtime: {
+      installFailed: {
+        title: 'Javaランタイムのインストールに失敗しました',
+        desc: '数分時間をあけて再度お試しください．({version})',
+      }
+    },
     missingPersonalAccessToken: {
       title: '{owner}/{repo}のパーソナルアクセストークンが存在しません',
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1818,6 +1818,15 @@ available-typed-arrays@^1.0.7:
   dependencies:
     possible-typed-array-names "^1.0.0"
 
+axios@^1.9.0:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.9.0.tgz#25534e3b72b54540077d33046f77e3b8d7081901"
+  integrity sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==
+  dependencies:
+    follow-redirects "^1.15.6"
+    form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
+
 b4a@^1.6.4:
   version "1.6.4"
   resolved "https://registry.yarnpkg.com/b4a/-/b4a-1.6.4.tgz#ef1c1422cae5ce6535ec191baeed7567443f36c9"
@@ -3771,6 +3780,11 @@ flora-colossus@^2.0.0:
     debug "^4.3.4"
     fs-extra "^10.1.0"
 
+follow-redirects@^1.15.6:
+  version "1.15.9"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.9.tgz#a604fa10e443bf98ca94228d9eebcc2e8a2c8ee1"
+  integrity sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==
+
 for-each@^0.3.3:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/for-each/-/for-each-0.3.3.tgz#69b447e88a0a5d32c3e7084f3f1710034b21376e"
@@ -5697,6 +5711,11 @@ proxy-addr@~2.0.7:
   dependencies:
     forwarded "0.2.0"
     ipaddr.js "1.9.1"
+
+proxy-from-env@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
 pump@^3.0.0:
   version "3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1818,15 +1818,6 @@ available-typed-arrays@^1.0.7:
   dependencies:
     possible-typed-array-names "^1.0.0"
 
-axios@^1.9.0:
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.9.0.tgz#25534e3b72b54540077d33046f77e3b8d7081901"
-  integrity sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==
-  dependencies:
-    follow-redirects "^1.15.6"
-    form-data "^4.0.0"
-    proxy-from-env "^1.1.0"
-
 b4a@^1.6.4:
   version "1.6.4"
   resolved "https://registry.yarnpkg.com/b4a/-/b4a-1.6.4.tgz#ef1c1422cae5ce6535ec191baeed7567443f36c9"
@@ -3780,11 +3771,6 @@ flora-colossus@^2.0.0:
     debug "^4.3.4"
     fs-extra "^10.1.0"
 
-follow-redirects@^1.15.6:
-  version "1.15.9"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.9.tgz#a604fa10e443bf98ca94228d9eebcc2e8a2c8ee1"
-  integrity sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==
-
 for-each@^0.3.3:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/for-each/-/for-each-0.3.3.tgz#69b447e88a0a5d32c3e7084f3f1710034b21376e"
@@ -5711,11 +5697,6 @@ proxy-addr@~2.0.7:
   dependencies:
     forwarded "0.2.0"
     ipaddr.js "1.9.1"
-
-proxy-from-env@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
-  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
 pump@^3.0.0:
   version "3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3539,6 +3539,11 @@ etag@~1.8.1:
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
   integrity sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==
 
+eventemitter3@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-5.0.1.tgz#53f5ffd0a492ac800721bb42c66b841de96423c4"
+  integrity sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==
+
 expand-template@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/expand-template/-/expand-template-2.0.3.tgz#6e14b3fcee0f3a6340ecb57d2e8918692052a47c"
@@ -5389,6 +5394,19 @@ p-locate@^5.0.0:
   integrity sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==
   dependencies:
     p-limit "^3.0.2"
+
+p-queue@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/p-queue/-/p-queue-8.1.0.tgz#d71929249868b10b16f885d8a82beeaf35d32279"
+  integrity sha512-mxLDbbGIBEXTJL0zEx8JIylaj3xQ7Z/7eEVjcF9fJX4DBiH9oqe+oahYnlKKxm0Ci9TlWTyhSHgygxMxjIB2jw==
+  dependencies:
+    eventemitter3 "^5.0.1"
+    p-timeout "^6.1.2"
+
+p-timeout@^6.1.2:
+  version "6.1.4"
+  resolved "https://registry.yarnpkg.com/p-timeout/-/p-timeout-6.1.4.tgz#418e1f4dd833fa96a2e3f532547dd2abdb08dbc2"
+  integrity sha512-MyIV3ZA/PmyBN/ud8vV9XzwTrNtR4jFrObymZYnZqMmW0zA8Z17vnT0rBgFE/TlohB+YCHqXMgZzb3Csp49vqg==
 
 p-try@^1.0.0:
   version "1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3539,11 +3539,6 @@ etag@~1.8.1:
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
   integrity sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==
 
-eventemitter3@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-5.0.1.tgz#53f5ffd0a492ac800721bb42c66b841de96423c4"
-  integrity sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==
-
 expand-template@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/expand-template/-/expand-template-2.0.3.tgz#6e14b3fcee0f3a6340ecb57d2e8918692052a47c"
@@ -5394,19 +5389,6 @@ p-locate@^5.0.0:
   integrity sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==
   dependencies:
     p-limit "^3.0.2"
-
-p-queue@^8.1.0:
-  version "8.1.0"
-  resolved "https://registry.yarnpkg.com/p-queue/-/p-queue-8.1.0.tgz#d71929249868b10b16f885d8a82beeaf35d32279"
-  integrity sha512-mxLDbbGIBEXTJL0zEx8JIylaj3xQ7Z/7eEVjcF9fJX4DBiH9oqe+oahYnlKKxm0Ci9TlWTyhSHgygxMxjIB2jw==
-  dependencies:
-    eventemitter3 "^5.0.1"
-    p-timeout "^6.1.2"
-
-p-timeout@^6.1.2:
-  version "6.1.4"
-  resolved "https://registry.yarnpkg.com/p-timeout/-/p-timeout-6.1.4.tgz#418e1f4dd833fa96a2e3f532547dd2abdb08dbc2"
-  integrity sha512-MyIV3ZA/PmyBN/ud8vV9XzwTrNtR4jFrObymZYnZqMmW0zA8Z17vnT0rBgFE/TlohB+YCHqXMgZzb3Csp49vqg==
 
 p-try@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
# 概要

V2側で実装されたJavaRuntimeのインストールプロセスを導入

Minecraft公式Runtimeのほか，Correttoなどの別Runtimeを見据えた実装を導入しつつ，Runtimeファイル群展開プロセスの最適化を行った

ログの整理やMockの実装も行うことで，テスト実行に配慮する実装に一部修正した