### PR TITLE
Version一覧のUIに対する問題を修正

### DIFF
--- a/src-electron/source/server/process.ts
+++ b/src-electron/source/server/process.ts
@@ -22,8 +22,8 @@ export function serverProcess(
   // javaのサブプロセスを起動
   // TODO: エラー出力先のハンドル
 
-  const stdout = (chunk: string) => console(chunk, false);
-  const stderr = (chunk: string) => console(chunk, true);
+  const stdout = (chunk: string) => splitLine(chunk, false, console);
+  const stderr = (chunk: string) => splitLine(chunk, true, console);
 
   const process = interactiveProcess(
     javaPath,
@@ -59,4 +59,14 @@ export function serverProcess(
   });
 
   return result;
+}
+
+function splitLine(
+  chunk: string,
+  isError: boolean,
+  console: (value: string, isError: boolean) => void
+) {
+  chunk.split(/\n|\r\n/).forEach((line) => {
+    console(line, isError);
+  });
 }

--- a/src-electron/source/version/readyVersions/base.ts
+++ b/src-electron/source/version/readyVersions/base.ts
@@ -50,7 +50,11 @@ abstract class BaseVersionProcess<V extends Exclude<Version, UnknownVersion>> {
    */
   protected _cachedSecondaryFiles: (string | RegExp)[];
 
-  constructor(version: V, cacheFolder: Path, cachedSecondaryFiles?: (string | RegExp)[]) {
+  constructor(
+    version: V,
+    cacheFolder: Path,
+    cachedSecondaryFiles?: (string | RegExp)[]
+  ) {
     this._version = version;
     this._cacheFolder = cacheFolder;
     this._cachedSecondaryFiles = [

--- a/src-electron/source/version/readyVersions/forge.ts
+++ b/src-electron/source/version/readyVersions/forge.ts
@@ -17,7 +17,12 @@ function getServerID(version: ForgeVersion) {
 }
 
 // ReadyVersionの標準対応以外のキャッシュからコピーすべきファイル群
-const SUPPORT_SECONDARY_FILES = ['version.bat', 'version.sh'];
+// 古いForgeは`version.json`とサーバーの実態Jarが分離しているため，これに対応するために正規表現で実態Jarもコピーする
+const SUPPORT_SECONDARY_FILES = [
+  'version.bat',
+  'version.sh',
+  /^(?!installer\.jar$).*\.jar$/,
+];
 
 export class ReadyForgeVersion extends ReadyVersion<ForgeVersion> {
   constructor(version: ForgeVersion, cacheFolder: Path) {
@@ -61,7 +66,11 @@ export class ReadyForgeVersion extends ReadyVersion<ForgeVersion> {
     if (isError(installerRes)) return installerRes;
 
     // `installer.jar`を実行
-    const runtime = await this.getRuntime('minecraft', verJsonHandler);
+    // installer.jarは常に最新のJavaで実行する
+    const runtime: Runtime = {
+      type: 'minecraft',
+      version: 'java-runtime-delta',
+    };
     if (isError(runtime)) return runtime;
     const installerRunRes = await getServerJarFromInstaller(
       installerPath,

--- a/src-electron/util/binary/path.ts
+++ b/src-electron/util/binary/path.ts
@@ -293,7 +293,16 @@ export class Path {
     if (!this.exists()) return;
     await target.parent().mkdir(true);
     await target.remove();
-    await fs.copy(this.path, target.path);
+    try {
+      await fs.copy(this.path, target.path);
+    } catch {
+      const isDir = await this._isDirectory();
+      if (isError(isDir)) return isDir;
+      return errorMessage.data.path.copyFailed({
+        type: isDir ? 'directory' : 'file',
+        path: this.path,
+      });
+    }
   }
 
   moveTo = exclusive(this._moveTo);

--- a/src-electron/util/error/schema/data.ts
+++ b/src-electron/util/error/schema/data.ts
@@ -64,6 +64,9 @@ export type DataErrors = {
     // ファイルまたはディレクトリの削除に失敗
     deletionFailed: PathErrorContent;
 
+    // ファイルまたはディレクトリのコピーに失敗
+    copyFailed: PathErrorContent;
+
     // ファイルまたはディレクトリの移動に失敗
     moveFailed: PathErrorContent;
 

--- a/src/components/World/HOME/Top/VersionSelecter/FabricView.vue
+++ b/src/components/World/HOME/Top/VersionSelecter/FabricView.vue
@@ -26,15 +26,15 @@ const latestReleaseID = prop.versionData.games.find((ops) => ops.release)?.id;
 
 function buildFabricVer(
   ver: { id: VersionId; release: boolean },
-  installer: string,
-  loader: string
+  installer: { version: string; stable: boolean },
+  loader: { version: string; stable: boolean }
 ): FabricVersion {
   return {
     id: ver.id,
     type: 'fabric' as const,
     release: ver.release,
-    installer: installer,
-    loader: loader,
+    installer: installer.version,
+    loader: loader.version,
   };
 }
 /**
@@ -42,8 +42,8 @@ function buildFabricVer(
  */
 function updateWorldVersion(
   ver: { id: VersionId; release: boolean },
-  installer: string,
-  loader: string
+  installer: { version: string; stable: boolean },
+  loader: { version: string; stable: boolean }
 ) {
   if (mainStore.world?.version) {
     mainStore.world.version = buildFabricVer(ver, installer, loader);
@@ -90,13 +90,11 @@ const fixInvalidIdx = (idx: number) => {
 const recommendInstallerIdx = fixInvalidIdx(
   prop.versionData.installers.findIndex((i) => i.stable)
 );
-const fabricInstaller = ref(
-  prop.versionData.installers[recommendInstallerIdx].version
-);
+const fabricInstaller = ref(prop.versionData.installers[recommendInstallerIdx]);
 const recommendLoaderIdx = fixInvalidIdx(
   prop.versionData.loaders.findIndex((i) => i.stable)
 );
-const fabricLoader = ref(prop.versionData.loaders[recommendLoaderIdx].version);
+const fabricLoader = ref(prop.versionData.loaders[recommendLoaderIdx]);
 
 // 表示内容と内部データを整合させる
 if (fabricVer.value !== '') {
@@ -150,9 +148,12 @@ if (fabricVer.value !== '') {
   <div class="row justify-between q-gutter-md">
     <SsSelect
       v-model="fabricInstaller"
-      @update:modelValue="(newVal: string) => {
-        if (fabricVer !== '') updateWorldVersion(fabricVer, newVal, fabricLoader)
-      }"
+      @update:modelValue="
+        (newVal) => {
+          if (fabricVer !== '')
+            updateWorldVersion(fabricVer, newVal, fabricLoader);
+        }
+      "
       :options="
         prop.versionData.installers.map((installer, i) => {
           return {
@@ -173,9 +174,12 @@ if (fabricVer.value !== '') {
     />
     <SsSelect
       v-model="fabricLoader"
-      @update:modelValue="(newVal: string) => {
-        if (fabricVer !== '') updateWorldVersion(fabricVer, fabricInstaller, newVal)
-      }"
+      @update:modelValue="
+        (newVal) => {
+          if (fabricVer !== '')
+            updateWorldVersion(fabricVer, fabricInstaller, newVal);
+        }
+      "
       :options="
         prop.versionData.loaders.map((loader, i) => {
           return {

--- a/src/components/util/base/ssSelect.vue
+++ b/src/components/util/base/ssSelect.vue
@@ -36,18 +36,22 @@ function convertStructure(modelVal: T) {
   };
 }
 
-// 選択肢一覧を構造化し，「その他」の多言語表示に対応する
-const editedOptions = (prop.options ?? []).map(convertStructure);
+const getOptions = (ops?: readonly any[]) => {
+  // 選択肢一覧を構造化し，「その他」の多言語表示に対応する
+  const editedOptions = (ops ?? []).map(convertStructure);
 
-// 選択肢一覧に「その他」を追加する
-// （本来はT型しか入れられないところに強引にOtherを入れるため，Modelが文字列型の時のみ対応する）
-// --> Modelの型制限が過剰な場合は適切な検証のもとに制限を緩和しても良い
-if (prop.enableOther && typeof model.value === 'string') {
-  editedOptions.push({
-    [definedOptionLabel]: $T('general.other') as T,
-    [definedOptionValue]: OTHER_DATA,
-  });
-}
+  // 選択肢一覧に「その他」を追加する
+  // （本来はT型しか入れられないところに強引にOtherを入れるため，Modelが文字列型の時のみ対応する）
+  // --> Modelの型制限が過剰な場合は適切な検証のもとに制限を緩和しても良い
+  if (prop.enableOther && typeof model.value === 'string') {
+    editedOptions.push({
+      [definedOptionLabel]: $T('general.other') as T,
+      [definedOptionValue]: OTHER_DATA,
+    });
+  }
+
+  return editedOptions;
+};
 
 // model.valueがOptionsに含まれているかどうかを判定する
 // Objectが来た時に包含判定が崩れないよう，inを使わずにsomeを使う
@@ -75,7 +79,7 @@ const computedModel = computed({
     <q-select
       v-model="computedModel"
       filled
-      :options="editedOptions"
+      :options="getOptions(options)"
       :label="label"
       :dense="dense"
       :popup-content-style="{ fontSize: '0.9rem' }"

--- a/src/i18n/en-US/Other/error.ts
+++ b/src/i18n/en-US/Other/error.ts
@@ -48,7 +48,7 @@ export const enUSError: MessageSchema['error'] = {
       },
       renameFailed: {
         title: 'Failed to rename the {type}',
-        desc: 'failed for {path}',
+        desc: 'Please reboot this PC after closing all servers. ({path})',
       },
       alreadyExists: {
         title: '{type} already exists',
@@ -109,19 +109,19 @@ export const enUSError: MessageSchema['error'] = {
       },
       creationFailed: {
         title: 'Failed to create {type}',
-        desc: 'Failed to create {path}',
+        desc: 'Please try rebooting this PC or check the write permission. ({path})',
       },
       deletionFailed: {
         title: 'Failed to delete {type}',
-        desc: 'Failed to delete {path}',
+        desc: 'Please reboot PC after closing all servers. ({path})',
       },
       copyFailed: {
         title: 'Failed to copy {type}',
-        desc: 'Failed to copy {path}',
+        desc: 'Please reboot PC after closing all servers. ({path})',
       },
       moveFailed: {
         title: 'Failed to move {type}',
-        desc: 'Failed to move {path}',
+        desc: 'Please reboot PC after closing all servers. ({path})',
       },
       dialogCanceled: {
         title: 'Window to select file is cancelled',

--- a/src/i18n/en-US/Other/error.ts
+++ b/src/i18n/en-US/Other/error.ts
@@ -115,6 +115,10 @@ export const enUSError: MessageSchema['error'] = {
         title: 'Failed to delete {type}',
         desc: 'Failed to delete {path}',
       },
+      copyFailed: {
+        title: 'Failed to copy {type}',
+        desc: 'Failed to copy {path}',
+      },
       moveFailed: {
         title: 'Failed to move {type}',
         desc: 'Failed to move {path}',

--- a/src/i18n/ja/Other/error.ts
+++ b/src/i18n/ja/Other/error.ts
@@ -117,6 +117,10 @@ export const jaError: ErrorTranslationTypes & ErrorDialogTitles = {
         title: '{type}の削除に失敗しました',
         desc: '{path}の削除ができませんでした',
       },
+      copyFailed: {
+        title: '{type}のコピーに失敗しました',
+        desc: '{path}のコピーができませんでした',
+      },
       moveFailed: {
         title: '{type}の移動に失敗しました',
         desc: '{path}の移動ができませんでした',

--- a/src/i18n/ja/Other/error.ts
+++ b/src/i18n/ja/Other/error.ts
@@ -50,7 +50,7 @@ export const jaError: ErrorTranslationTypes & ErrorDialogTitles = {
       },
       renameFailed: {
         title: '{type}のリネームに失敗しました',
-        desc: '{path}をリネームできませんでした',
+        desc: '全てのサーバーを閉じたうえでPCの再起動をお試しください．({path})',
       },
       alreadyExists: {
         title: '{type}が既に存在しています',
@@ -111,19 +111,19 @@ export const jaError: ErrorTranslationTypes & ErrorDialogTitles = {
       },
       creationFailed: {
         title: '{type}の生成に失敗しました',
-        desc: '{path}の生成ができませんでした',
+        desc: 'PCの再起動や書き込み権限をご確認ください．({path})',
       },
       deletionFailed: {
         title: '{type}の削除に失敗しました',
-        desc: '{path}の削除ができませんでした',
+        desc: '全てのサーバーを閉じたうえでPCの再起動をお試しください．({path})',
       },
       copyFailed: {
         title: '{type}のコピーに失敗しました',
-        desc: '{path}のコピーができませんでした',
+        desc: '全てのサーバーを閉じたうえでPCの再起動をお試しください．({path})',
       },
       moveFailed: {
         title: '{type}の移動に失敗しました',
-        desc: '{path}の移動ができませんでした',
+        desc: '全てのサーバーを閉じたうえでPCの再起動をお試しください．({path})',
       },
       dialogCanceled: {
         title: 'ファイル選択ウィンドウがキャンセルされました',


### PR DESCRIPTION
# 概要

Version一覧のUIにおいて，以下のような問題が生じていたため，フロントエンド側の処理を修正した

- バニラのバージョンリストのUIにおいて，「すべてのバージョン」を選択してもスナップショットが選択できない
- PaperMC / Forge / Fabric のビルド番号一覧がバージョンを選択し直した際に反映されない

また，この修正に伴い，過去バージョンを選択した際に正しくサーバーが起動することも確認した

> SpigotについてはBuilderに使うUniversalJavaの特定が未修正のため未検証


## その他の修正
- 過去バージョンのForgeを起動した際に，`installer.jar`によって生成されたファイル群のうち，サーバーの実行に必要な`minecraft_server.1.VV.v.jar`がキャッシュからワールドフォルダにコピーされていない問題を修正
- `installer.jar`の実行Javaのバージョンを`java-runtime-delta`に固定
- Fabricの実装において，LoaderとInstallerに設定する値の誤りを修正
- サーバー実行時のコンソール内に改行コードが含まれる場合は，コンソール一行として送信するデータを分割
- `Path.copyTo()`実行時に`fs.copy()`が失敗して無限待機する問題を修正
- ファイル操作失敗時のエラーメッセージにPCの再起動を促す文言を追加
（多くのファイル操作エラーは，ゴースト化したサーバーがバックグラウンドに取り残されていることが原因のため）