### PR TITLE
Universal Javaのバージョニングを修正

### DIFF
--- a/src-electron/source/runtime/getUnivConfig.ts
+++ b/src-electron/source/runtime/getUnivConfig.ts
@@ -15,7 +15,7 @@ import { runtimeLoggers } from './base';
 const logger = runtimeLoggers().univConfig();
 
 // betaとgammaはメジャーバージョンが共に17のため，より新しいgammaを優先する
-const EXCLUDE_COMPONENTS = ['java-runtime-beta'] as const;
+const EXCLUDE_COMPONENTS = ['java-runtime-beta', 'java-runtime-gamma-snapshot'] as const;
 const McTargetComponent = z.string();
 type McTargetComponent = z.infer<typeof McTargetComponent>;
 

--- a/src-electron/source/runtime/getUnivConfig.ts
+++ b/src-electron/source/runtime/getUnivConfig.ts
@@ -95,14 +95,15 @@ function findNearestLowerVersion(
 export function getUniversalConfig(
   osPlatform: OsPlatform,
   mcRuntimeManifest: McRuntimeManifest,
-  majorVersion: JavaMajorVersion
+  majorVersion: JavaMajorVersion | undefined
 ): Promise<Failable<Exclude<Runtime, UniversalRuntime>>> {
   const converters = getConvertersJdk2Component(mcRuntimeManifest);
 
   // versionがconvertersに存在しない場合は小さい側の直近のバージョンを表示する
+  // majorVersionが指定されていない場合は最新のバージョンを表示する
   const runtimeComponentName = findNearestLowerVersion(
     converters[osPlatform],
-    majorVersion
+    majorVersion ?? 10 ** 3
   );
   if (runtimeComponentName) {
     return Promise.resolve({
@@ -110,11 +111,12 @@ export function getUniversalConfig(
       version: runtimeComponentName,
     });
   } else {
+    // TODO: 「/path/to/install にインストールしてください」というエラーメッセージに変更
     return Promise.resolve(
       errorMessage.core.runtime.installFailed({
         runtimeType: 'universal',
         targetOs: osPlatform,
-        version: majorVersion.toString(),
+        version: majorVersion?.toString() ?? 'LATEST RUNTIME VERSION',
       })
     );
   }

--- a/src-electron/source/runtime/getUnivConfig.ts
+++ b/src-electron/source/runtime/getUnivConfig.ts
@@ -15,7 +15,10 @@ import { runtimeLoggers } from './base';
 const logger = runtimeLoggers().univConfig();
 
 // betaとgammaはメジャーバージョンが共に17のため，より新しいgammaを優先する
-const EXCLUDE_COMPONENTS = ['java-runtime-beta', 'java-runtime-gamma-snapshot'] as const;
+const EXCLUDE_COMPONENTS = [
+  'java-runtime-beta',
+  'java-runtime-gamma-snapshot',
+] as const;
 const McTargetComponent = z.string();
 type McTargetComponent = z.infer<typeof McTargetComponent>;
 

--- a/src-electron/source/runtime/manifest.ts
+++ b/src-electron/source/runtime/manifest.ts
@@ -62,6 +62,13 @@ export abstract class JavaRuntimeInstaller<
     throw new Error('setRuntimeManifest() not implemented');
   }
 
+  /**
+   * キャッシュに指定したデータを取得する
+   */
+  getCache(): Promise<Failable<RM>> {
+    return this.accessor.get();
+  }
+
   protected static getCacheableAccessor<RM extends RuntimeManifest>(
     validator: z.ZodSchema<RM, z.ZodTypeDef, any>,
     manifestPath: Path,
@@ -172,7 +179,7 @@ export abstract class JavaRuntimeInstaller<
     });
 
     // RuntimeのManifestを取得
-    const allManifest = await this.accessor.get();
+    const allManifest = await this.getCache();
     if (isError(allManifest)) return allManifest;
     logger.info('Get `all-manifest` successfully');
 

--- a/src-electron/source/runtime/minecraft.ts
+++ b/src-electron/source/runtime/minecraft.ts
@@ -17,7 +17,10 @@ export class MinecraftRuntimeInstaller extends JavaRuntimeInstaller<
 > {
   static readonly manifestName = 'minecraft' as const;
 
-  static setRuntimeManifest(manifestPath: Path, manifestUrl: string) {
+  static setRuntimeManifest(
+    manifestPath: Path,
+    manifestUrl: string
+  ): MinecraftRuntimeInstaller {
     return new MinecraftRuntimeInstaller(
       this.getCacheableAccessor(McRuntimeManifest, manifestPath, manifestUrl)
     );

--- a/src-electron/source/runtime/runtime.ts
+++ b/src-electron/source/runtime/runtime.ts
@@ -39,7 +39,7 @@ export class RuntimeContainer {
     private getUniversalConfig: (
       osPlatform: OsPlatform,
       mcRuntimeManifest: McRuntimeManifest,
-      majorVersion: JavaMajorVersion
+      majorVersion: JavaMajorVersion | undefined
     ) => Promise<Failable<Exclude<Runtime, UniversalRuntime>>>
   ) {
     this.metaDirPath = cacheDirPath.child('meta');
@@ -50,6 +50,15 @@ export class RuntimeContainer {
         minecraftRuntimeManifestUrl
       ),
     };
+  }
+
+  /**
+   * 指定したOS，RuntimeTypeにおける最新版のRuntime情報を返す
+   */
+  async getLatestRuntime(osPlatform: OsPlatform): Promise<Failable<Runtime>> {
+    const mcRuntimeManifest = await this.installerMap.minecraft.getCache();
+    if (isError(mcRuntimeManifest)) return mcRuntimeManifest;
+    return this.getUniversalConfig(osPlatform, mcRuntimeManifest, undefined);
   }
 
   /**
@@ -117,7 +126,7 @@ export class RuntimeContainer {
     const refRuntimeOrError = await this.getUniversalConfig(
       osPlatform,
       mcRuntimeManifest,
-      runtime.majorVersion
+      runtime.majorVersion,
     );
     if (isError(refRuntimeOrError)) return refRuntimeOrError;
     const refRuntime = refRuntimeOrError;

--- a/src-electron/source/server/ready.ts
+++ b/src-electron/source/server/ready.ts
@@ -76,7 +76,17 @@ export async function readyRunServer(
 
     /** Spigotのビルド等に使用するランタイムを準備する */
     const execRuntime: ExecRuntime = async (args) => {
-      const javaPath = await readyRuntime(args.runtime);
+      // runtimeが指定されていない場合は最新版を適用
+      let targetRuntime = args.runtime;
+      if (!targetRuntime) {
+        const tmpTargetRuntime = await runtimeContainer.getLatestRuntime(
+          osPlatform
+        );
+        if (isError(tmpTargetRuntime)) return tmpTargetRuntime;
+        targetRuntime = tmpTargetRuntime;
+      }
+
+      const javaPath = await readyRuntime(targetRuntime);
       if (isError(javaPath)) return javaPath;
 
       return interactiveProcess(

--- a/src-electron/source/version/readyVersions/base.ts
+++ b/src-electron/source/version/readyVersions/base.ts
@@ -20,7 +20,7 @@ export function getJarPath(cwdPath: Path) {
 }
 
 export type ExecRuntime = (options: {
-  runtime: Runtime;
+  runtime?: Runtime;
   args: string[];
   currentDir: Path;
   onOut: (line: string) => void;

--- a/src-electron/source/version/readyVersions/spigot.ts
+++ b/src-electron/source/version/readyVersions/spigot.ts
@@ -103,15 +103,11 @@ export class ReadySpigotVersion extends ReadyVersion<SpigotVersion> {
     if (isError(installerRes)) return installerRes;
     p?.delete();
 
-    const runtime = await this.getRuntime('universal', verJsonHandler);
-    if (isError(runtime)) return runtime;
-
     // `BuildTools.jar`を実行して，`server.jar`を抽出
     return getServerJarFromBuildTools(
       this._version.id,
       installerPath,
       this.cachePath,
-      runtime,
       execRuntime,
       progress
     );
@@ -161,7 +157,6 @@ async function getServerJarFromBuildTools(
   versionId: VersionId,
   buildToolsPath: Path,
   serverCachePath: Path,
-  runtime: Runtime,
   execRuntime: ExecRuntime,
   progress?: GroupProgressor
 ): Promise<Failable<void>> {
@@ -175,10 +170,11 @@ async function getServerJarFromBuildTools(
   ];
 
   // BuildToolsを実行して，Jarファイルを生成
+  // BuildToolsの実行に用いるRuntimeは常に最新版を使用する
   const sp = progress?.subtitle({ key: 'server.readyVersion.spigot.building' });
   const cp = progress?.console();
   const buildRes = await execRuntime({
-    runtime,
+    runtime: undefined,
     args,
     currentDir: buildToolsPath.parent(),
     onOut(line) {

--- a/src-electron/source/version/readyVersions/spigot.ts
+++ b/src-electron/source/version/readyVersions/spigot.ts
@@ -75,7 +75,8 @@ export class ReadySpigotVersion extends ReadyVersion<SpigotVersion> {
       url: SPIGOT_BUILDTOOL_URL,
     };
     returnVerJson.javaVersion = {
-      majorVersion: spigotVerInfo.javaVersions[1],
+      // Class File Version -> JDK major version
+      majorVersion: spigotVerInfo.javaVersions[1] - 44,
     };
     p?.delete();
     return returnVerJson;

--- a/src-electron/source/version/readyVersions/spigot.ts
+++ b/src-electron/source/version/readyVersions/spigot.ts
@@ -223,14 +223,14 @@ if (import.meta.vitest) {
     const cacheFolder = workPath.child('cache');
     const serverFolder = workPath.child('servers');
 
-    const ver21: SpigotVersion = {
-      id: VersionId.parse('1.21'),
+    const ver19: SpigotVersion = {
+      id: VersionId.parse('1.19'),
       type: 'spigot',
     };
 
     test('setSpigotJar', { timeout: 1000 * 60 }, async () => {
-      const outputPath = serverFolder.child(ver21.id);
-      const readyOperator = new ReadySpigotVersion(ver21, cacheFolder);
+      const outputPath = serverFolder.child(ver19.id);
+      const readyOperator = new ReadySpigotVersion(ver19, cacheFolder);
       const cachePath = readyOperator.cachePath;
 
       // 条件をそろえるために，ファイル類を削除する
@@ -255,8 +255,13 @@ if (import.meta.vitest) {
 
       // 戻り値の検証
       expect(res.getCommand({ jvmArgs: ['replaceArg'] })[0]).toBe('replaceArg');
+      expect(res.runtime).toMatchObject({
+        type: 'universal',
+        majorVersion: 18,
+      })
 
       // execRuntime が正しい引数で呼ばれている
+      // BuildTools実行時のRuntimeは常に最新版を利用するため，呼び出し時はundefinedとなる
       expect(execRuntime).toHaveBeenCalledTimes(1);
       expect(execRuntime).toHaveBeenNthCalledWith(1, {
         args: [
@@ -264,14 +269,11 @@ if (import.meta.vitest) {
           '-jar',
           expect.any(String),
           '--rev',
-          '1.21',
+          '1.19',
         ],
         currentDir: expect.any(Path),
         onOut: expect.any(Function),
-        runtime: {
-          majorVersion: expect.any(Number),
-          type: 'universal',
-        },
+        runtime: undefined,
       });
 
       // ファイルの設置状況の検証
@@ -280,7 +282,7 @@ if (import.meta.vitest) {
       // expect(outputPath.child('libraries').exists()).toBe(true);
 
       // 実行後にファイル削除
-      const remover = new RemoveSpigotVersion(ver21, cacheFolder);
+      const remover = new RemoveSpigotVersion(ver19, cacheFolder);
       await remover.completeRemoveVersion(outputPath);
 
       // 削除後の状態を確認

--- a/src-electron/source/version/readyVersions/spigot.ts
+++ b/src-electron/source/version/readyVersions/spigot.ts
@@ -266,7 +266,6 @@ if (import.meta.vitest) {
       });
 
       // execRuntime が正しい引数で呼ばれている
-      // BuildTools実行時のRuntimeは常に最新版を利用するため，呼び出し時はundefinedとなる
       expect(execRuntime).toHaveBeenCalledTimes(1);
       expect(execRuntime).toHaveBeenNthCalledWith(1, {
         args: [
@@ -278,7 +277,10 @@ if (import.meta.vitest) {
         ],
         currentDir: expect.any(Path),
         onOut: expect.any(Function),
-        runtime: undefined,
+        runtime: {
+          type: 'universal',
+          majorVersion: 18,
+        },
       });
 
       // ファイルの設置状況の検証


### PR DESCRIPTION
# 概要

Spigotのビルド等で使用するJDKバージョンから使用するRuntimeを指定する方式（Universal Java）において，JDKバージョンとクラスファイルバージョンを取り間違えているためにSpigotを起動できない問題を修正

原則としてSpigotのAPIに記載されたJava Versionはクラスファイルバージョンであるため，これを44減じることでJDKバージョン（Java21などの表記）に変換している

現行のシステムが対応するコンポーネント以外の新コンポーネントが出た際にも警告を出すのみで処理は続行する実装に修正


## Java8の不完全性について

本PRを経てもJava8を使用するSpigotのバージョンは実行できない

これはMinecraft側が提供するJava8（jre-legacy）の認証情報が欠けていることによるものであり，Correttoを使用した場合はビルド可能である．

今後Correttoに置換する際に本問題へ対応する