### PR TITLE
MohistMCのAPI変更をサポート

### DIFF
--- a/src-electron/schema/version.ts
+++ b/src-electron/schema/version.ts
@@ -50,10 +50,11 @@ export const MohistmcVersion = z.object({
   type: z.literal('mohistmc'),
   id: VersionId,
   forge_version: z.string().optional(),
-  buildId: z.string(),
+  buildId: z.number(),
+  buildName: z.string(),
   jar: z.object({
     url: z.string(),
-    md5: z.string(),
+    sha256: z.string().optional(),
   }),
 });
 export type MohistmcVersion = z.infer<typeof MohistmcVersion>;
@@ -114,11 +115,12 @@ export const AllMohistmcVersion = z
     id: VersionId,
     builds: z
       .object({
-        id: z.string(),
+        id: z.number(),
+        name: z.string(),
         forge_version: z.string().optional(),
         jar: z.object({
           url: z.string(),
-          md5: z.string(),
+          sha256: z.string().optional(),
         }),
       })
       .array(),

--- a/src-electron/source/runtime/getUnivConfig.ts
+++ b/src-electron/source/runtime/getUnivConfig.ts
@@ -182,7 +182,8 @@ if (import.meta.vitest) {
       const cleanConfig = (obj: Record<string, any>) => {
         const runtimeComponentName = Object.keys(obj).filter(
           (k) =>
-            McTargetComponent.safeParse(k).success && (obj[k]?.length ?? 0 > 0)
+            !EXCLUDE_COMPONENTS.some((c) => c === k) &&
+            (obj[k]?.length ?? 0) > 0
         );
         return fromEntries(
           runtimeComponentName.map((n) => [

--- a/src-electron/source/server/process.ts
+++ b/src-electron/source/server/process.ts
@@ -68,7 +68,7 @@ function splitLine(
 ) {
   // PR（#241）にて，改行を含むコンソール出力は分割してフロントエンドに送信していたが，
   // 同一の通信から受け取ったコンソールは意味のあるまとまりと考えて，この分割処理をせずに送信する仕様に戻した
-  console(chunk, isError)
+  console(chunk, isError);
   // chunk.split(/\n|\r\n/).forEach((line) => {
   //   console(line, isError);
   // });

--- a/src-electron/source/server/process.ts
+++ b/src-electron/source/server/process.ts
@@ -66,7 +66,10 @@ function splitLine(
   isError: boolean,
   console: (value: string, isError: boolean) => void
 ) {
-  chunk.split(/\n|\r\n/).forEach((line) => {
-    console(line, isError);
-  });
+  // PR（#241）にて，改行を含むコンソール出力は分割してフロントエンドに送信していたが，
+  // 同一の通信から受け取ったコンソールは意味のあるまとまりと考えて，この分割処理をせずに送信する仕様に戻した
+  console(chunk, isError)
+  // chunk.split(/\n|\r\n/).forEach((line) => {
+  //   console(line, isError);
+  // });
 }

--- a/src-electron/source/version/getVersions/mohistmc.ts
+++ b/src-electron/source/version/getVersions/mohistmc.ts
@@ -48,7 +48,7 @@ export class MohistMCVersionLoader extends VersionListLoader<'mohistmc'> {
 
   async getFromURL() {
     // 全バージョンのメタ情報を読み込み
-    const allVerMeta = await loadAllVersion();
+    const allVerMeta = await this.loadAllVersion();
     if (isError(allVerMeta)) return allVerMeta;
 
     // メタ情報を各バージョンオブジェクトに変換
@@ -57,18 +57,22 @@ export class MohistMCVersionLoader extends VersionListLoader<'mohistmc'> {
     );
     return results.filter(isValid);
   }
-}
 
-/**
- * 全てのバージョンのメタ情報を収集
- */
-async function loadAllVersion(): Promise<Failable<string[]>> {
-  const jsonBytes = await BytesData.fromURL(mohistAllVersionsURL);
-  if (isError(jsonBytes)) return jsonBytes;
-  const parsedJson = await jsonBytes.json(mohistAllVersionsZod);
-  if (isError(parsedJson)) return parsedJson;
+  /**
+   * 全てのバージョンのメタ情報を収集
+   */
+  private async loadAllVersion(): Promise<Failable<string[]>> {
+    const jsonBytes = await BytesData.fromURL(mohistAllVersionsURL);
+    if (isError(jsonBytes)) return jsonBytes;
+    const parsedJson = await jsonBytes.json(mohistAllVersionsZod);
+    if (isError(parsedJson)) return parsedJson;
 
-  return parsedJson.map((v) => v.name);
+    const versions = parsedJson.map((v) => v.name);
+
+    // idsをバージョン順に並び替え
+    await this.sortIds(versions);
+    return versions.reverse();
+  }
 }
 
 /**

--- a/src-electron/source/version/getVersions/spigot.ts
+++ b/src-electron/source/version/getVersions/spigot.ts
@@ -4,7 +4,6 @@ import { Path } from 'app/src-electron/util/binary/path';
 import { isError } from 'app/src-electron/util/error/error';
 import { AllSpigotVersion, VersionId } from '../../../schema/version';
 import { VersionListLoader } from './base';
-import { getVersionMainfest } from './manifest';
 
 const SPIGOT_VERSIONS_URL = 'https://hub.spigotmc.org/versions/';
 
@@ -47,22 +46,5 @@ export class SpigotVersionLoader extends VersionListLoader<'spigot'> {
       .map((id) => ({
         id: id as VersionId,
       }));
-  }
-
-  /**
-   * HTMLから取得したID一覧をManifestに掲載の順番で並び替える
-   */
-  private async sortIds(ids: string[]) {
-    const manifest = await getVersionMainfest(this.cachePath, true);
-    if (isError(manifest)) return;
-
-    // Manifest掲載のバージョン順を取得
-    const entries: [string, number][] = manifest.versions.map(
-      (version, index) => [version.id, index]
-    );
-    const versionIndexMap = Object.fromEntries(entries);
-
-    // 取得したバージョン順で`ids`を並び替え
-    ids.sort((a, b) => versionIndexMap[a] - versionIndexMap[b]);
   }
 }

--- a/src-electron/source/version/readyVersions/mohistmc.ts
+++ b/src-electron/source/version/readyVersions/mohistmc.ts
@@ -104,7 +104,8 @@ if (import.meta.vitest) {
       buildName: '2c49e69c7d50fa5ba8210c8648cc8d0f9135fe22',
       jar: {
         url: 'https://api.mohistmc.com/project/mohist/1.20.1/builds/157/download',
-        sha256: '922f21008d63230033e85565fbff959f2a5158e23021ef4c5343c51d096757d0',
+        sha256:
+          '922f21008d63230033e85565fbff959f2a5158e23021ef4c5343c51d096757d0',
       },
     };
 

--- a/src-electron/source/version/readyVersions/mohistmc.ts
+++ b/src-electron/source/version/readyVersions/mohistmc.ts
@@ -33,7 +33,7 @@ export class ReadyMohistMCVersion extends ReadyVersion<MohistmcVersion> {
     const returnVerJson = deepcopy(vanillaVerJson);
     returnVerJson.download = {
       url: this._version.jar.url,
-      hash: this._version.jar.md5,
+      hash: this._version.jar.sha256,
     };
     return returnVerJson;
   }
@@ -53,7 +53,7 @@ export class ReadyMohistMCVersion extends ReadyVersion<MohistmcVersion> {
     // Jarをダウンロード
     const hash: Hash | undefined = verJson.download.hash
       ? {
-          type: 'md5',
+          type: 'sha256',
           value: verJson.download.hash,
         }
       : undefined;
@@ -98,12 +98,13 @@ if (import.meta.vitest) {
     const serverFolder = workPath.child('servers');
 
     const ver20: MohistmcVersion = {
-      id: '1.20.1' as VersionId,
       type: 'mohistmc',
-      buildId: '5b34f54e5abee608fa6035b12e9fda85b414e9e0',
+      id: '1.20.1' as VersionId,
+      buildId: 157,
+      buildName: '2c49e69c7d50fa5ba8210c8648cc8d0f9135fe22',
       jar: {
-        url: 'https://mohistmc.com/api/v2/projects/mohist/1.20.1/builds/5b34f54e5abee608fa6035b12e9fda85b414e9e0/download',
-        md5: '8923b0e1bf3ac9eae61ae41714918547',
+        url: 'https://api.mohistmc.com/project/mohist/1.20.1/builds/157/download',
+        sha256: '922f21008d63230033e85565fbff959f2a5158e23021ef4c5343c51d096757d0',
       },
     };
 

--- a/src/components/World/HOME/Top/VersionSelecter/MohistMCView.vue
+++ b/src/components/World/HOME/Top/VersionSelecter/MohistMCView.vue
@@ -27,10 +27,11 @@ type MohistBuildType = AllMohistmcVersion[number]['builds'][number];
  * 描画する際にForgeの対応番号を記載する
  */
 function getNumberName(build: MohistBuildType) {
+  const showingName = build.name.slice(0, 8);
   if (build.forge_version !== void 0) {
-    return `${build.id.slice(0, 8)} (Forge: ${build.forge_version})`;
+    return `${showingName} (Forge: ${build.forge_version})`;
   } else {
-    return build.id;
+    return showingName;
   }
 }
 
@@ -42,6 +43,7 @@ function buildMohistVer(
     id: id,
     type: 'mohistmc' as const,
     buildId: build.id,
+    buildName: build.name,
     jar: toRaw(build.jar),
     forge_version: build.forge_version,
   };
@@ -87,12 +89,9 @@ const mohistBuilds = (mVer: string): MohistBuildType[] => {
   return (
     prop.versionData.find((ver) => ver.id === mVer)?.builds ?? [
       {
-        id: 'invalidId',
-        jar: {
-          url: '',
-          md5: '',
-        },
-        forge_version: undefined,
+        id: -1,
+        name: 'invalidBuild',
+        jar: { url: '' },
       },
     ]
   );
@@ -105,10 +104,11 @@ const mohistBuild = computed({
     }
     return {
       id: mainStore.world.version.buildId,
+      name: mainStore.world.version.buildName,
       forge_version: mainStore.world.version.forge_version,
       jar: {
         url: mainStore.world.version.jar.url,
-        md5: mainStore.world.version.jar.md5,
+        sha256: mainStore.world.version.jar.sha256,
       },
     };
   },


### PR DESCRIPTION
# 概要

またしてもMohistMCのAPI通信先URLの変更と，APIスキーマが変更となったため，これに対応するための修正を実施


## 変更箇所

- [x] スキーマ変更に伴う実装修正
- [x] バージョン一覧のソート機能をSpigot専属から大元の`VersionListLoader`に移築
- ~~MohistMCの各バージョンスキーマが以前までと変更になったことを受けて，変換プログラムを実装~~
読み込めなくなったバージョンについてはUnknownとする実装を次のPRで実施

### その他の変更
- [x] 以前のPR（#241）にて，改行を含むコンソール出力は分割してフロントエンドに送信していたが，同一の通信から受け取ったコンソールは意味のあるまとまりと考えて，この分割処理をせずに送信する仕様に戻した
- [x] `java-runtime-gamma-snapshot`がテストケースにて除外されていなかった問題を修正