### PR TITLE
Version設定が読み込めなかった場合は，Unknown Versionを適用する

### DIFF
--- a/src-electron/schema/version.ts
+++ b/src-electron/schema/version.ts
@@ -150,15 +150,17 @@ export const AllFabricVersion = z.object({
 });
 export type AllFabricVersion = z.infer<typeof AllFabricVersion>;
 
-export const Version = z.discriminatedUnion('type', [
-  UnknownVersion,
-  VanillaVersion,
-  SpigotVersion,
-  PapermcVersion,
-  ForgeVersion,
-  MohistmcVersion,
-  FabricVersion,
-]);
+export const Version = z
+  .discriminatedUnion('type', [
+    UnknownVersion,
+    VanillaVersion,
+    SpigotVersion,
+    PapermcVersion,
+    ForgeVersion,
+    MohistmcVersion,
+    FabricVersion,
+  ])
+  .catch({ type: 'unknown' });
 export type Version = z.infer<typeof Version>;
 
 export type VersionType = Version['type'];

--- a/src-electron/source/version/getVersions/mohistmc.ts
+++ b/src-electron/source/version/getVersions/mohistmc.ts
@@ -98,8 +98,10 @@ async function loadEachVersion(
           url: mohistJarURL(versionName, b.id),
         },
       };
-    })
-    .reverse();
+    });
+
+  // 掲載順がめちゃくちゃのため，ビルドIDの降順に並び替える
+  builds.sort((a, b) => b.id - a.id);
 
   return {
     id: VersionId.parse(versionName),

--- a/src-electron/source/world/base.ts
+++ b/src-electron/source/world/base.ts
@@ -1,0 +1,3 @@
+import { sourceLoggers } from '../sourceLogger';
+
+export const worldLoggers = () => sourceLoggers().world;

--- a/src-electron/source/world/files/json.ts
+++ b/src-electron/source/world/files/json.ts
@@ -6,7 +6,10 @@ import { Remote } from 'app/src-electron/schema/remote';
 import { Version } from 'app/src-electron/schema/version';
 import { errorMessage } from 'app/src-electron/util/error/construct';
 import { isError } from 'app/src-electron/util/error/error';
+import { worldLoggers } from '../base';
 import { ServerSettingFile } from './base';
+
+const logger = worldLoggers().json;
 
 /**
  * ワールドのディレクトリ構成
@@ -67,17 +70,15 @@ export const serverJsonFile: ServerSettingFile<WorldSettings> = {
     const jsonPath = cwdPath.child(WORLD_SETTINGS_PATH);
 
     const data = await jsonPath.readJson(WorldSettings);
-    if (isError(data)) return data;
-
-    const fixed = WorldSettings.safeParse(data);
-
-    if (!fixed.success)
+    if (isError(data)) {
+      logger.load(cwdPath.path).error(data);
       return errorMessage.data.path.invalidContent.invalidWorldSettingJson({
         type: 'file',
         path: jsonPath.path,
       });
+    }
 
-    return fixed.data;
+    return data;
   },
   async save(cwdPath, value) {
     const jsonPath = cwdPath.child(WORLD_SETTINGS_PATH);

--- a/src/components/MainLayout/WorldList.vue
+++ b/src/components/MainLayout/WorldList.vue
@@ -76,7 +76,7 @@ const drawer = ref(true);
           v-for="(world, idx) in mainStore.allWorlds.filteredWorlds()"
           :key="world"
         >
-          <WorldTab :world_item="world" :idx="idx" />
+          <WorldTab :world-item="world" :idx="idx" />
         </template>
       </q-list>
     </q-scroll-area>

--- a/src/components/World/HOME/RunningBtn.vue
+++ b/src/components/World/HOME/RunningBtn.vue
@@ -2,6 +2,7 @@
 import { getCssVar } from 'quasar';
 import { assets } from 'src/assets/assets';
 import { runServer, useConsoleStore } from 'src/stores/ConsoleStore';
+import { useErrorWorldStore } from 'src/stores/ErrorWorldStore';
 import { useMainStore } from 'src/stores/MainStore';
 import SsBtn from 'src/components/util/base/ssBtn.vue';
 import SsI18nT from 'src/components/util/base/ssI18nT.vue';
@@ -13,6 +14,7 @@ interface Prop {
 defineProps<Prop>();
 
 const mainStore = useMainStore();
+const errorWorldStore = useErrorWorldStore();
 const consoleStore = useConsoleStore();
 
 function stopServer() {
@@ -33,7 +35,7 @@ function stopButtonState() {
     free-width
     color="primary"
     :disable="
-      mainStore.errorWorlds.has(mainStore.selectedWorldID) ||
+      errorWorldStore.isError(mainStore.selectedWorldID) ||
       consoleStore.status(mainStore.selectedWorldID) !== 'Stop'
     "
     :to="to"

--- a/src/components/World/HOME/Top/VersionSelecter/ForgeView.vue
+++ b/src/components/World/HOME/Top/VersionSelecter/ForgeView.vue
@@ -73,12 +73,17 @@ const forgeVer = computed({
   },
 });
 
+/**
+ * デフォルトのビルド（最新ビルドまたは推奨バージョン）を取得する
+ */
+function getDefaultBuild() {
+  return forgeVer.value.recommended ?? forgeVer.value.forge_versions[0];
+}
+
 const forgeBuild = computed({
   get: () => {
     // 前のバージョンがPaperでない時は，最新のビルド番号を割り当てる
-    if (mainStore.world?.version.type !== 'forge') {
-      return forgeVer.value.recommended ?? forgeVer.value.forge_versions[0];
-    }
+    if (mainStore.world?.version.type !== 'forge') return getDefaultBuild();
     return {
       version: mainStore.world.version.forge_version,
       url: mainStore.world.version.download_url,
@@ -122,7 +127,7 @@ updateWorldVersion(forgeVer.value.id, forgeBuild.value);
           return {
             data: build,
             label:
-              forgeVer.recommended?.version === build.version
+              getDefaultBuild().version === build.version
                 ? `${build.version} (${$T('home.version.recommend')})`
                 : build.version,
           };

--- a/src/components/World/HOME/Top/VersionSelecter/versionComparator.ts
+++ b/src/components/World/HOME/Top/VersionSelecter/versionComparator.ts
@@ -30,20 +30,26 @@ export function getHashs<T>(ops: T[]) {
   return Promise.all(ops.map((v) => getHashData(v)));
 }
 
+/**
+ * 変更前後のサーバー種別を比較して，サーバー種別の変更が入る際には警告を表示する
+ */
 export function openVerTypeWarningDialog<T extends Version['type']>(
   $q: QVueGlobals,
   currentType: T,
   newType: T
 ) {
   const mainStore = useMainStore();
+  const successFunc = () => (mainStore.selectedVersionType = newType);
+
+  // サーバー種別が不明な場合は，特に警告を出さない
+  if (currentType === 'unknown') return successFunc();
+
   __openWarningDialog(
     $q,
     [currentType, newType],
     currentType,
     newType,
-    () => {
-      mainStore.selectedVersionType = newType;
-    },
+    successFunc,
     'versionChange'
   );
 }

--- a/src/components/World/HOME/Top/VersionSelecterView.vue
+++ b/src/components/World/HOME/Top/VersionSelecterView.vue
@@ -8,6 +8,7 @@ import {
   AllPapermcVersion,
   AllSpigotVersion,
   AllVanillaVersion,
+  Version,
   versionTypes,
 } from 'app/src-electron/schema/version';
 import { assets } from 'src/assets/assets';
@@ -63,6 +64,16 @@ function createServerMap(serverType: (typeof versionTypes)[number]) {
   };
 }
 
+/**
+ * 選択されたバージョン設定がUnknownでない場合は，エラー一覧からワールドを除外する
+ */
+function clearErrWrold(versionType: Version['type']) {
+  const worldId = mainStore.selectedWorldID;
+  console.log(versionType)
+  if (versionType === 'unknown') mainStore.errorWorlds.add(worldId);
+  else mainStore.errorWorlds.delete(worldId);
+}
+
 const selectedVerType = computed({
   get: () => {
     return mainStore.selectedVersionType;
@@ -74,9 +85,11 @@ const selectedVerType = computed({
 </script>
 
 <template>
+  {{ mainStore.errorWorlds }}
   <!-- その際に、すでに存在しているバージョンのタイプのみは選択できるようにする -->
   <SsSelectScope
     v-model="selectedVerType"
+    @update:model-value="clearErrWrold(selectedVerType)"
     :options="validVersionTypes.map(createServerMap)"
     options-selected-class="text-primary"
     :label="$T('home.version.serverType')"

--- a/src/components/World/HOME/Top/VersionSelecterView.vue
+++ b/src/components/World/HOME/Top/VersionSelecterView.vue
@@ -14,6 +14,10 @@ import {
 import { assets } from 'src/assets/assets';
 import { $T } from 'src/i18n/utils/tFunc';
 import { useConsoleStore } from 'src/stores/ConsoleStore';
+import {
+  UNKNOWN_VERSION_ERROR_REASON,
+  useErrorWorldStore,
+} from 'src/stores/ErrorWorldStore';
 import { useMainStore } from 'src/stores/MainStore';
 import { useSystemStore } from 'src/stores/SystemStore';
 import SsSelectScope from 'src/components/util/base/ssSelectScope.vue';
@@ -29,6 +33,7 @@ import { openVerTypeWarningDialog } from './VersionSelecter/versionComparator';
 const $q = useQuasar();
 const sysStore = useSystemStore();
 const mainStore = useMainStore();
+const errorWorldStore = useErrorWorldStore();
 const consoleStore = useConsoleStore();
 
 // エラーが発生してバージョン一覧の取得ができなかったバージョンを選択させない
@@ -69,9 +74,12 @@ function createServerMap(serverType: (typeof versionTypes)[number]) {
  */
 function clearErrWrold(versionType: Version['type']) {
   const worldId = mainStore.selectedWorldID;
-  console.log(versionType)
-  if (versionType === 'unknown') mainStore.errorWorlds.add(worldId);
-  else mainStore.errorWorlds.delete(worldId);
+
+  if (versionType === 'unknown') {
+    errorWorldStore.lock(worldId, UNKNOWN_VERSION_ERROR_REASON);
+  } else {
+    errorWorldStore.unlock(worldId, UNKNOWN_VERSION_ERROR_REASON);
+  }
 }
 
 const selectedVerType = computed({
@@ -85,7 +93,6 @@ const selectedVerType = computed({
 </script>
 
 <template>
-  {{ mainStore.errorWorlds }}
   <!-- その際に、すでに存在しているバージョンのタイプのみは選択できるようにする -->
   <SsSelectScope
     v-model="selectedVerType"

--- a/src/components/World/HOME/Top/VersionSelecterView.vue
+++ b/src/components/World/HOME/Top/VersionSelecterView.vue
@@ -82,6 +82,16 @@ function clearErrWrold(versionType: Version['type']) {
   }
 }
 
+/**
+ * unknownバージョンはバリデーション違反として表示する
+ */
+function validateVersion(versionType: Version['type']) {
+  if (versionType === 'unknown') {
+    return $T('home.version.unknownError');
+  }
+  return true;
+}
+
 const selectedVerType = computed({
   get: () => {
     return mainStore.selectedVersionType;
@@ -101,6 +111,7 @@ const selectedVerType = computed({
     options-selected-class="text-primary"
     :label="$T('home.version.serverType')"
     :disable="consoleStore.status(mainStore.selectedWorldID) !== 'Stop'"
+    :rules="[(val) => validateVersion(val)]"
     class="q-pb-md"
   >
     <template v-slot:option="scope">

--- a/src/components/World/HOME/Top/WorldNameView.vue
+++ b/src/components/World/HOME/Top/WorldNameView.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
-import { useI18n } from 'vue-i18n';
 import { isError } from 'app/src-public/scripts/error';
 import { WorldName } from 'app/src-electron/schema/brands';
+import { $T } from 'src/i18n/utils/tFunc';
 import { useConsoleStore } from 'src/stores/ConsoleStore';
 import { useErrorWorldStore } from 'src/stores/ErrorWorldStore';
 import { useMainStore } from 'src/stores/MainStore';
@@ -10,7 +10,6 @@ import SsInput from 'src/components/util/base/ssInput.vue';
 const mainStore = useMainStore();
 const consoleStore = useConsoleStore();
 const errorWorldStore = useErrorWorldStore();
-const { t } = useI18n();
 
 const VALIDATION_ERROR = 'world_name_is_invalid';
 const EMPTY_ERROR = 'world_name_is_empty';
@@ -23,7 +22,7 @@ async function validateWorldName(name: WorldName) {
 
   if (name === '') {
     errorWorldStore.lock(mainStore.selectedWorldID, EMPTY_ERROR);
-    return t(`error.${EMPTY_ERROR}.desc`);
+    return $T('home.worldName.emptyError');
   } else {
     errorWorldStore.unlock(mainStore.selectedWorldID, EMPTY_ERROR);
   }
@@ -35,7 +34,7 @@ async function validateWorldName(name: WorldName) {
 
   if (isError(res) && mainStore.world.name !== name) {
     errorWorldStore.lock(mainStore.selectedWorldID, VALIDATION_ERROR);
-    return t(`error.${res.key}.desc`);
+    return $T(`error.${res.key}.desc`);
   } else {
     errorWorldStore.unlock(mainStore.selectedWorldID, VALIDATION_ERROR);
     mainStore.world.name = name;

--- a/src/components/World/HOME/Top/WorldNameView.vue
+++ b/src/components/World/HOME/Top/WorldNameView.vue
@@ -3,30 +3,41 @@ import { useI18n } from 'vue-i18n';
 import { isError } from 'app/src-public/scripts/error';
 import { WorldName } from 'app/src-electron/schema/brands';
 import { useConsoleStore } from 'src/stores/ConsoleStore';
+import { useErrorWorldStore } from 'src/stores/ErrorWorldStore';
 import { useMainStore } from 'src/stores/MainStore';
 import SsInput from 'src/components/util/base/ssInput.vue';
 
 const mainStore = useMainStore();
 const consoleStore = useConsoleStore();
+const errorWorldStore = useErrorWorldStore();
 const { t } = useI18n();
+
+const VALIDATION_ERROR = 'world_name_is_invalid';
+const EMPTY_ERROR = 'world_name_is_empty';
 
 /**
  * ワールド名のバリデーションを行う
  */
 async function validateWorldName(name: WorldName) {
-  if (!mainStore.world) {
-    return true;
+  if (!mainStore.world) return true;
+
+  if (name === '') {
+    errorWorldStore.lock(mainStore.selectedWorldID, EMPTY_ERROR);
+    return t(`error.${EMPTY_ERROR}.desc`);
+  } else {
+    errorWorldStore.unlock(mainStore.selectedWorldID, EMPTY_ERROR);
   }
 
   const res = await window.API.invokeValidateNewWorldName(
     mainStore.world.container,
     name
   );
+
   if (isError(res) && mainStore.world.name !== name) {
-    mainStore.errorWorlds.add(mainStore.selectedWorldID);
+    errorWorldStore.lock(mainStore.selectedWorldID, VALIDATION_ERROR);
     return t(`error.${res.key}.desc`);
   } else {
-    mainStore.errorWorlds.delete(mainStore.selectedWorldID);
+    errorWorldStore.unlock(mainStore.selectedWorldID, VALIDATION_ERROR);
     mainStore.world.name = name;
     return true;
   }
@@ -37,7 +48,7 @@ async function validateWorldName(name: WorldName) {
  */
 function clearNewName() {
   // 空文字列のワールドは起動できないため、エラー扱い
-  mainStore.errorWorlds.add(mainStore.selectedWorldID);
+  errorWorldStore.lock(mainStore.selectedWorldID, EMPTY_ERROR);
 }
 </script>
 

--- a/src/components/util/base/ssSelectScope.vue
+++ b/src/components/util/base/ssSelectScope.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import { QSelect } from 'quasar';
 import { onMounted, ref } from 'vue';
+import { QSelect } from 'quasar';
 
 interface Prop {
   options?: readonly any[];
@@ -18,7 +18,7 @@ const model = defineModel();
 const selectRef = ref<InstanceType<typeof QSelect> | null>(null);
 
 onMounted(() => {
-  selectRef.value?.validate()
+  selectRef.value?.validate();
 });
 </script>
 

--- a/src/components/util/base/ssSelectScope.vue
+++ b/src/components/util/base/ssSelectScope.vue
@@ -1,4 +1,7 @@
 <script setup lang="ts">
+import { QSelect } from 'quasar';
+import { onMounted, ref } from 'vue';
+
 interface Prop {
   options?: readonly any[];
   label?: string;
@@ -12,10 +15,16 @@ interface Prop {
 
 const prop = defineProps<Prop>();
 const model = defineModel();
+const selectRef = ref<InstanceType<typeof QSelect> | null>(null);
+
+onMounted(() => {
+  selectRef.value?.validate()
+});
 </script>
 
 <template>
   <q-select
+    ref="selectRef"
     v-model="model"
     filled
     :options="options"

--- a/src/components/util/base/ssSelectScope.vue
+++ b/src/components/util/base/ssSelectScope.vue
@@ -7,6 +7,7 @@ interface Prop {
   optionLabel?: string;
   optionValue?: string;
   loading?: boolean;
+  rules?: ((val: any) => boolean | string)[];
 }
 
 const prop = defineProps<Prop>();
@@ -21,6 +22,7 @@ const model = defineModel();
     :label="label"
     :dense="dense"
     :loading="loading"
+    :rules="rules"
     :popup-content-style="{ fontSize: '0.9rem' }"
     :disable="disable"
     emit-value

--- a/src/i18n/en-US/Pages/World/home.ts
+++ b/src/i18n/en-US/Pages/World/home.ts
@@ -20,6 +20,7 @@ export const enUSHome: MessageSchema['home'] = {
     latestSnapshot: 'Latest snapshot',
     latestRelease: 'Latest release',
     latestVersion: 'Latest version',
+    unknownError: 'This version is unknown. Please specify the version.',
   },
   versionChange: {
     title: 'Checking change the server type',

--- a/src/i18n/en-US/Pages/World/home.ts
+++ b/src/i18n/en-US/Pages/World/home.ts
@@ -4,6 +4,7 @@ export const enUSHome: MessageSchema['home'] = {
   worldName: {
     title: 'World Name',
     enterName: 'Enter your world name',
+    emptyError: 'Please enter your world name',
   },
   version: {
     title: 'Versions',

--- a/src/i18n/ja/Pages/World/home.ts
+++ b/src/i18n/ja/Pages/World/home.ts
@@ -18,6 +18,7 @@ export const jaHome = {
     latestSnapshot: '最新のスナップショット',
     latestRelease: '最新のリリース',
     latestVersion: '最新のバージョン',
+    unknownError: 'バージョン情報が不明です。バージョンを指定してください。',
   },
   versionChange: {
     title: 'サーバーの種類を変更',

--- a/src/i18n/ja/Pages/World/home.ts
+++ b/src/i18n/ja/Pages/World/home.ts
@@ -2,6 +2,7 @@ export const jaHome = {
   worldName: {
     title: 'ワールド名',
     enterName: '半角英数字でワールド名を入力',
+    emptyError: 'ワールド名を入力してください',
   },
   version: {
     title: 'バージョン',

--- a/src/init.ts
+++ b/src/init.ts
@@ -89,7 +89,10 @@ export async function getWorlds(wIds: WorldID[]) {
   worlds.forEach((wFailable, idx) => {
     checkError(
       wFailable.value,
-      (w) => updateWorld(w),
+      (w) => {
+        if (w.version.type === 'unknown') mainStore.errorWorlds.add(w.id);
+        updateWorld(w);
+      },
       (e) => {
         const errObj = tError(e);
         const wId = wIds[idx];

--- a/src/init.ts
+++ b/src/init.ts
@@ -2,6 +2,10 @@ import { keys, values } from 'app/src-public/scripts/obj/obj';
 import { versionTypes } from 'app/src-electron/schema/version';
 import { WorldID } from 'app/src-electron/schema/world';
 import { tError } from './i18n/utils/tFunc';
+import {
+  UNKNOWN_VERSION_ERROR_REASON,
+  useErrorWorldStore,
+} from './stores/ErrorWorldStore';
 import { useMainStore } from './stores/MainStore';
 import { useSystemStore } from './stores/SystemStore';
 import {
@@ -78,7 +82,7 @@ export async function afterWindow() {
  * ワールドの詳細情報を取得する
  */
 export async function getWorlds(wIds: WorldID[]) {
-  const mainStore = useMainStore();
+  const errorWorldStore = useErrorWorldStore();
 
   // Worldの詳細情報
   const worlds = await Promise.all(
@@ -90,14 +94,16 @@ export async function getWorlds(wIds: WorldID[]) {
     checkError(
       wFailable.value,
       (w) => {
-        if (w.version.type === 'unknown') mainStore.errorWorlds.add(w.id);
+        if (w.version.type === 'unknown')
+          errorWorldStore.lock(w.id, UNKNOWN_VERSION_ERROR_REASON);
         updateWorld(w);
       },
       (e) => {
+        const ERROR_REASON = 'init_world_is_invalid';
         const errObj = tError(e);
         const wId = wIds[idx];
         // 正常に取得できなかったワールドを登録
-        mainStore.errorWorlds.add(wId);
+        errorWorldStore.lock(wId, ERROR_REASON);
         // エラー理由を登録
         registWorldError(wId, errObj);
         return errObj;

--- a/src/pages/WorldPage.vue
+++ b/src/pages/WorldPage.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { useRouter } from 'vue-router';
 import { keys } from 'app/src-public/scripts/obj/obj';
+import { useErrorWorldStore } from 'src/stores/ErrorWorldStore';
 import { useMainStore } from 'src/stores/MainStore';
 import FailedLoadingView from 'src/components/World/FailedLoadingView.vue';
 import HeaderView from 'src/components/World/HeaderView.vue';
@@ -9,6 +10,8 @@ import SettingTabsView from 'src/components/World/SettingTabsView.vue';
 
 const router = useRouter();
 const mainStore = useMainStore();
+const errorWorldStore = useErrorWorldStore();
+
 const isSelectSuggestMode = () =>
   router.currentRoute.value.path.slice(0, 7) !== '/system' &&
   mainStore.selectedWorldID === '';
@@ -22,7 +25,7 @@ const isLoading = () =>
 const isFailedLoading = () =>
   router.currentRoute.value.path.slice(0, 7) !== '/system' &&
   mainStore.world === void 0 &&
-  mainStore.errorWorlds.has(mainStore.selectedWorldID);
+  errorWorldStore.isError(mainStore.selectedWorldID);
 </script>
 
 <template>

--- a/src/stores/ErrorWorldStore.ts
+++ b/src/stores/ErrorWorldStore.ts
@@ -1,0 +1,33 @@
+import { defineStore } from 'pinia';
+import { keys } from 'app/src-public/scripts/obj/obj';
+import { WorldID } from 'app/src-electron/schema/brands';
+
+export const UNKNOWN_VERSION_ERROR_REASON = 'server_type_is_unknown';
+
+export const useErrorWorldStore = defineStore('errorWorldStore', {
+  state: () => {
+    return {
+      errorWorlds: {} as Record<WorldID, Set<string>>,
+    };
+  },
+  actions: {
+    /**
+     * ワールドをロック（エラー原因は任意の文字列で表現する）
+     */
+    lock(worldID: WorldID, reasonKey: string) {
+      if (!keys(this.errorWorlds).includes(worldID)) {
+        this.errorWorlds[worldID] = new Set<string>();
+      }
+      this.errorWorlds[worldID].add(reasonKey);
+    },
+    unlock(worldID: WorldID, reasonKey: string) {
+      if (keys(this.errorWorlds).includes(worldID)) {
+        this.errorWorlds[worldID].delete(reasonKey);
+      }
+    },
+    isError(worldID: WorldID): boolean {
+      const errorCounts = this.errorWorlds[worldID]?.size ?? 0;
+      return errorCounts > 0;
+    },
+  },
+});

--- a/src/stores/MainStore.ts
+++ b/src/stores/MainStore.ts
@@ -24,7 +24,6 @@ export const useMainStore = defineStore('mainStore', {
       selectedWorldID: '' as WorldID,
       inputWorldName: '' as WorldName,
       worldSearchText: '',
-      errorWorlds: new Set<WorldID>(),
       selectedVersionType: 'vanilla' as Version['type'],
       worldIPs: {} as Record<WorldID, string>,
     };


### PR DESCRIPTION
# 概要

`server_config.json`において，Version設定が不適の場合，以前まではワールド全体の読み込みエラーとしていたが，当該ワールドはUnknown Versionとして読み込むこととした

また，#244 でのMohistMCの仕様変更を踏まえて，以前まで起動していたMohistのワールドはすべてUnknown Versionとして読み込まれることとなった

## 変更内容
- ワールドの起動制限プロセスを変更（SetにWorldIDをためる -> Storeで制限理由とともに管理）
- Unknownバージョンとなった際に入力エラーとして検知し，これがタブの切り替えの際にも適用されるように`SsSelectScope`を修正
- 各バージョンにおけるデータの持ち方を修正
（バージョンIDのほかにビルドID等を持つ場合，AllVersionsからの検索回数が減るように修正することでパフォーマンスを向上）
- MohistMCのビルド一覧の順序をソート

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 不明なサーバータイプのエラーハンドリング機能を追加しました
  * ワールド名とバージョン選択の検証ルールを追加しました

* **バグ修正**
  * ワールド初期化時の不正なバージョン処理を改善しました
  * バージョン選択時にデフォルト値へのフォールバック機能を追加しました

* **改善**
  * ユーザーに対する検証エラーメッセージが明確になりました
  * バージョン情報の表示をより一貫性のある形式に統一しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->