### PR TITLE
PaperMCの最古バージョンを更新

### DIFF
--- a/src-electron/source/version/version.test.ts
+++ b/src-electron/source/version/version.test.ts
@@ -54,7 +54,7 @@ describe('listupVersions', async () => {
     {
       type: 'papermc',
       vcList: () => vc.listVersions('papermc', useCache),
-      oldestVersion: '1.8.8',
+      oldestVersion: '1.7.10',
     },
     {
       type: 'mohistmc',


### PR DESCRIPTION
# 概要
PaperMCの最古バージョンに1.7.10が追加されたことで，バージョンに関するテストがFailするようになってしまったため，テストの内容を更新

全てのテストが問題なく実行されるように修正した

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Tests
  * Updated PaperMC version list test to expect the oldest version as 1.7.10 (previously 1.8.8), aligning tests with actual available versions.
  * Improves test accuracy and reduces false CI failures, enhancing reliability of version validation and release confidence.
  * Ensures future changes are verified against the correct baseline for supported versions.
  * No functional or UI changes; no user-facing impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->